### PR TITLE
Allow exceptions where we load jQuery in <head>

### DIFF
--- a/erudit/apps/userspace/editor/views.py
+++ b/erudit/apps/userspace/editor/views.py
@@ -81,6 +81,9 @@ class IssueSubmissionUpdate(IssueSubmissionCheckMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context['model_name'] = "editor.IssueSubmission"
         context['model_pk'] = self.object.pk
+        # In this view, we have a widget, plupload, that injects JS in the page. This JS needs
+        # jquery. Because of this, we need to load jquery in the header rather than in the footer.
+        context['put_js_in_head'] = True
         return context
 
     def get_success_url(self):

--- a/erudit/templates/base.html
+++ b/erudit/templates/base.html
@@ -30,13 +30,16 @@
     {% else %}
     {% stylesheet 'erudit_main' %}
     {% endif %}
+    {% if put_js_in_head %}
+        {% include 'partials/global_js_include.html' %}
+    {% endif %}
     {% block extrahead %}
     {% endblock %}
   </head>
   <body class="{% block body_class %}{% endblock %}">
 
     {% block header %}
-    {% endblock %}    
+    {% endblock %}
     {% block nav %}
     {% endblock %}
     {% block content %}
@@ -45,13 +48,8 @@
     {% endblock %}
 
 
-    {# scripts #}
-    {% if DEBUG %}
-    <script src="{% static 'js/build/erudit-vendors-dev.js' %}"></script>
-    <script src="{% static 'js/build/erudit-scripts-dev.js' %}"></script>
-    {% else %}
-    {% javascript 'erudit_vendors' %}
-    {% javascript 'erudit_scripts' %}
+    {% if not put_js_in_head %}
+        {% include 'partials/global_js_include.html' %}
     {% endif %}
 
     {% block footerscript %}

--- a/erudit/templates/partials/global_js_include.html
+++ b/erudit/templates/partials/global_js_include.html
@@ -1,0 +1,11 @@
+{% load pipeline %}
+{% load staticfiles %}
+
+{# scripts #}
+{% if DEBUG %}
+<script src="{% static 'js/build/erudit-vendors-dev.js' %}"></script>
+<script src="{% static 'js/build/erudit-scripts-dev.js' %}"></script>
+{% else %}
+{% javascript 'erudit_vendors' %}
+{% javascript 'erudit_scripts' %}
+{% endif %}


### PR DESCRIPTION
In the issue submission form, we have inline JS being injected by a
widget. That injected JS requires jQuery, and it fails because jQuery is
only loaded at the bottom of the page.

This commit adds a new template context option, `put_js_in_head` which
moves JS includes in the head rather than at the bottom of the body.