### PR TITLE
Fix unstable test

### DIFF
--- a/erudit/erudit/tests/test_models.py
+++ b/erudit/erudit/tests/test_models.py
@@ -38,7 +38,7 @@ class TestJournal(BaseEruditTestCase):
         issue_2 = IssueFactory.create(journal=self.journal, date_published=dt.datetime.now())
         IssueFactory.create(journal=self.journal, date_published=None)
         # Run & check
-        self.assertEqual(list(self.journal.published_issues), [issue_1, issue_2, ])
+        self.assertEqual(set(self.journal.published_issues), {issue_1, issue_2})
 
     def test_can_return_its_first_issue(self):
         # Setup


### PR DESCRIPTION
Fix a test that used ordered list to compare elemens for which the order
is undefined. This results in false failures on some systems.