### PR TITLE
Add event trigger for issue submission workflow changes

### DIFF
--- a/erudit/apps/userspace/editor/tests/test_events.py
+++ b/erudit/apps/userspace/editor/tests/test_events.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from lxml import etree
 
 from erudit.models import Event
 from core.editor.models import IssueSubmission
@@ -6,11 +7,23 @@ from core.editor.tests.base import BaseEditorTestCase
 
 
 class TestIssueSubmissionEvents(BaseEditorTestCase):
+    def setUp(self):
+        super().setUp()
+        self.previous_event_count = Event.objects.count()
+
+    def expect_new_event(self):
+        self.assertEquals(
+            Event.objects.count(),
+            self.previous_event_count + 1,
+            "An event should have been created"
+        )
+        result = Event.objects.last()
+        self.previous_event_count = Event.objects.count()
+        return result
+
     def test_issuesubmission_creation_triggers_event(self):
         """ Creating a new issue submission creates an Event
         """
-        event_count = Event.objects.count()
-
         data = {
             'journal': self.journal.pk,
             'year': '2015',
@@ -25,15 +38,36 @@ class TestIssueSubmissionEvents(BaseEditorTestCase):
         url = reverse('userspace:editor:add')
         self.client.post(url, data)
 
-        self.assertEquals(
-            Event.objects.count(),
-            event_count + 1,
-            "An event should have been added"
-        )
-
-        event = Event.objects.last()
+        event = self.expect_new_event()
         submission = IssueSubmission.objects.last()
 
         self.assertEquals(event.type, Event.TYPE_SUBMISSION_CREATED)
         self.assertEquals(event.author, self.user)
         self.assertEquals(event.target_object, submission)
+
+    def test_issuesubmission_status_update_triggers_event(self):
+        """ Issue workflow transitions trigger events.
+
+            The comment of that event contains the new and old status.
+        """
+        self.client.login(username='david', password='top_secret')
+
+        url = reverse('userspace:editor:update', args=(self.issue_submission.pk, ))
+        response = self.client.get(url)
+
+        root = etree.HTML(response.content)
+        data = self.extract_post_args(root)
+        # self.issue_submission lacks some required fields...
+        data['year'] = '2015'
+        data['number'] = '2'
+        data['transition'] = 'submit'
+
+        response = self.client.post(url, data)
+
+        event = self.expect_new_event()
+
+        self.assertEquals(event.type, Event.TYPE_SUBMISSION_STATUS_CHANGE)
+        self.assertEquals(event.author, self.user)
+        self.assertEquals(event.target_object, self.issue_submission)
+        self.assertIn(IssueSubmission.DRAFT, event.comment)
+        self.assertIn(IssueSubmission.SUBMITTED, event.comment)

--- a/erudit/apps/userspace/editor/views.py
+++ b/erudit/apps/userspace/editor/views.py
@@ -101,6 +101,17 @@ class IssueSubmissionUpdate(WorkflowMixin,
 
         return context
 
+    def apply_transition(self, *args, **kwargs):
+        old_status = self.object.status
+        result = super().apply_transition(*args, **kwargs)
+        if self.object.status != old_status:
+            Event.change_submission_status(
+                author=self.request.user,
+                submission=self.object,
+                old_status=old_status
+            )
+        return result
+
     def get_success_url(self):
         return reverse('userspace:editor:issues')
 

--- a/erudit/erudit/models/event.py
+++ b/erudit/erudit/models/event.py
@@ -6,6 +6,11 @@ from django.utils.translation import gettext_lazy as _
 from django.template import defaultfilters
 
 
+# Implementation note: If you look around to see where these events are recorded, you'll see that
+# they's recorded at the view level. At first sight, using signals seems like a more proper hook
+# to use for event recording, but the problem is that we want to fill the ``author`` field and
+# we need to access the request for that. The request is not available during signal handling.
+
 class Event(models.Model):
     """ Tracks important events in the system.
 
@@ -47,7 +52,7 @@ class Event(models.Model):
 
     @classmethod
     def change_submission_status(cls, author, submission, old_status):
-        comment = "{} --> {}".format(old_status, submission.get_status_display())
+        comment = "{} --> {}".format(old_status, submission.status)
         return cls.objects.create(
             type=cls.TYPE_SUBMISSION_STATUS_CHANGE,
             author=author,


### PR DESCRIPTION
We now have new event created when the status of an issue submission
changes.

ref [redmine issue 194](https://redmine.erudit.team/issues/194)