### PR TITLE
#1861 - Issue detail

### DIFF
--- a/eruditorg/apps/public/search/forms.py
+++ b/eruditorg/apps/public/search/forms.py
@@ -49,8 +49,8 @@ FUNDS_CHOICES = (
 )
 
 PUB_TYPES_CHOICES = (
-    ('Article', _('Savantes')),
-    ('Culturel', _('Culturelles')),
+    ('Article', _('Articles savants')),
+    ('Culturel', _('Articles culturels')),
     ('Thèses', _('Thèses')),
     ('Livres', _('Livres')),
     ('Actes', _('Actes')),
@@ -240,10 +240,10 @@ class ResultsOptionsForm(forms.Form):
         label=_('Trier par...'),
         choices=[
             ('relevance', _('Pertinence')),
-            ('title_asc', _('Titre (ordre croissant)')),
-            ('title_desc', _('Titre (ordre décroissant)')),
-            ('author_asc', _('Premier auteur (ordre croissant)')),
-            ('author_desc', _('Premier auteur (ordre décroissant)')),
-            ('pubdate_asc', _('Date de publication (ordre croissant)')),
-            ('pubdate_desc', _('Date de publication (ordre décroissant)')),
+            ('title_asc', _('Titre (A–Z)')),
+            ('title_desc', _('Titre (Z–A)')),
+            ('author_asc', _('Premier auteur (A–Z)')),
+            ('author_desc', _('Premier auteur (Z–A)')),
+            ('pubdate_asc', _('Date de publication (croissant)')),
+            ('pubdate_desc', _('Date de publication (décroissant)')),
         ], required=False)

--- a/eruditorg/apps/public/thesis/views.py
+++ b/eruditorg/apps/public/thesis/views.py
@@ -78,12 +78,12 @@ class ThesisCollectionHomeView(DetailView):
 class BaseThesisListView(ListView):
     """ Base view for displaying a list of theses associated with a collection. """
     available_tris = OrderedDict((
-        ('author_asc', _('Auteur (croissant)')),
-        ('author_desc', _('Auteur (décroissant)')),
+        ('author_asc', _('Auteur (A–Z)')),
+        ('author_desc', _('Auteur (Z–A)')),
         ('date_asc', _("Date d'ajout (croissant)")),
         ('date_desc', _("Date d'ajout (décroissant)")),
-        ('title_asc', _('Titre (croissant)')),
-        ('title_desc', _('Titre (décroissant)')),
+        ('title_asc', _('Titre (A–Z)')),
+        ('title_desc', _('Titre (Z–A)')),
     ))
     collection_pk_url_kwarg = 'collection_pk'
     context_object_name = 'theses'

--- a/eruditorg/static/sass/pages/_issue-detail.scss
+++ b/eruditorg/static/sass/pages/_issue-detail.scss
@@ -11,27 +11,6 @@
 
   }
 
-  h3 {
-    margin-top: 20px;
-    font-size: 1.75em;
-    text-transform: none;
-  }
-
-  h4 {
-    margin-top: 10px;
-    margin-left: 20px;
-    font-size: 1.55em;
-    @include fw-sans-medium;
-    text-transform: none;
-  }
-
-  h5 {
-    margin-top: 10px;
-    margin-left: 50px;
-    font-size: 1.15em;
-    @include fw-sans-medium;
-  }
-
   /**
   * List of articles
   */

--- a/eruditorg/static/sass/pages/_issue-detail.scss
+++ b/eruditorg/static/sass/pages/_issue-detail.scss
@@ -7,6 +7,7 @@
 
     h2 {
       @include fw-sans-normal();
+      margin-bottom: 1em;
     }
 
   }
@@ -14,6 +15,40 @@
   /**
   * List of articles
   */
+  h3.section {
+    border-top: 1px solid $dark-grey;
+    color: $coral-red;
+  }
+
+  h4.section,
+  h5.section {
+    border-top: 1px solid $mid-grey;
+    margin-left: 20px;
+    color: #333;
+  }
+
+  h5.section {
+    margin-left: 40px;
+    color: $dark-grey;
+  }
+
+  h3.section + h4.section {
+    margin-left: 0;
+    text-indent: 20px;
+  }
+
+  h4.section + h5.section {
+    margin-left: 20px;
+    text-indent: 20px;
+  }
+
+  .section {
+    padding: 20px 0;
+    margin: 0;
+    font-size: 18px;
+    @include fw-sans-medium;
+  }
+
   .issue_detail--articles {
 
     &.section-2{
@@ -21,12 +56,16 @@
     }
 
     &.section-3{
-      margin-left: 50px;
+      margin-left: 40px;
     }
 
-    .issue_detail--article-item {
-      padding: 1.5em 0;
+    .article-item {
+      padding: 1em 0;
       border-bottom: 1px solid $mid-grey;
+
+      &:first-child {
+        border-top: 1px solid $mid-grey;
+      }
 
       &:last-child {
         border-bottom: none;
@@ -34,7 +73,8 @@
 
       .article-title {
         margin-bottom: 0.5em;
-        font-size: 1.25em;
+        font-size: 1.15em;
+        line-height: 1.25;
         @include fw-serif-normal;
 
         i, em {
@@ -43,14 +83,22 @@
 
       }
 
-      .issue_detail--article-item--author {
-        font-size: smaller;
-        margin-bottom: 1.75em;
+      .article-metadata {
+        margin-top: 1.25em;
+      }
+
+      .article-author {
+        font-size: 14px;
+      }
+
+      .article-pagination {
+        font-size: 12px;
+        text-align: right;
       }
 
       .toolbox {
-        margin: -2px 0 0 10px;
-        padding: 0 20px 0 0;
+        margin: 0 0 0 15px;
+        padding: 0;
         width: auto;
 
         a {

--- a/eruditorg/static/sass/pages/_issue-detail.scss
+++ b/eruditorg/static/sass/pages/_issue-detail.scss
@@ -32,10 +32,15 @@
         border-bottom: none;
       }
 
-      h6 {
+      .article-title {
         margin-bottom: 0.5em;
         font-size: 1.25em;
-        @include fw-sans-medium;
+        @include fw-serif-normal;
+
+        i, em {
+          @include fw-serif-normal-italic;
+        }
+
       }
 
       .issue_detail--article-item--author {
@@ -43,10 +48,33 @@
         margin-bottom: 1.75em;
       }
 
-      .btn-primary-outlined {
-        font-size: smaller;
-        padding: 0.5em 0.25em;
-        line-height: 1;
+      .toolbox {
+        margin: -2px 0 0 10px;
+        padding: 0 20px 0 0;
+        width: auto;
+
+        a {
+          margin-right: 1px;
+          padding: 8px 0;
+          display: inline-block;
+          width: 25px;
+          height: 25px;
+          background: $black;
+          color: $white;
+          font-size: 9px;
+          white-space: nowrap;
+          text-align: center;
+          vertical-align: middle;
+
+          &:hover, &:focus, &.saved {
+            background: $coral-red;
+          }
+
+          .erudicon-tools-pdf {
+            font-size: 6px;
+          }
+
+        }
 
       }
 

--- a/eruditorg/static/sass/pages/_issue-detail.scss
+++ b/eruditorg/static/sass/pages/_issue-detail.scss
@@ -130,4 +130,47 @@
 
   }
 
+  /**
+  * Back issues section
+  */
+
+  .back-issues {
+    background: $light-grey;
+
+    .back-issues--header {
+      font-size: 1.25em;
+    }
+
+    .issue-list--item img {
+      height: 175px;
+    }
+
+    .issue-list--title {
+      margin-top: 1em;
+
+      h5 {
+        margin: 0;
+      }
+
+      a {
+        border-top: 1px solid $dark-grey;
+        padding: 1em 0;
+        display: block;
+        @include transition(all 150ms);
+
+        &:hover, &:focus, &:active, &:active:focus {
+          background: $coral-red;
+          color: #FFF;
+          text-decoration: none;
+          @include fw-sans-medium;
+          padding: 1em 0.25em;
+          border-color: $coral-red;
+        }
+
+      }
+
+    }
+
+  }
+
 }

--- a/eruditorg/static/sass/pages/_issues.scss
+++ b/eruditorg/static/sass/pages/_issues.scss
@@ -4,7 +4,7 @@
 
 .back-issues {
   margin-top: $margin-vertical-default * 2;
-  background-color: $gray-lighter;
+  background: $light-grey;
   padding: $margin-vertical-default 0;
 
   .back-issues--header {
@@ -63,7 +63,7 @@
     }
   }
   .issue-list--theme {
-    @include fw-sans-bold;
+    @include fw-sans-medium;
     display: block;
     margin: 0.25em 0;
   }

--- a/eruditorg/static/sass/pages/_journals.scss
+++ b/eruditorg/static/sass/pages/_journals.scss
@@ -34,8 +34,14 @@
 
   h2 {
     border-bottom: 1px solid $mid-grey;
-    padding-bottom: 0.5em;
-    font-size: 1.5em;
+    padding-bottom: 0.35em;
+    font-size: 1.35em;
+  }
+
+  h3 {
+    border-bottom: 1px solid $mid-grey;
+    font-size: 1.15em;
+    padding-bottom: 0.15em;
   }
 
   p {

--- a/eruditorg/static/sass/vars/_public.scss
+++ b/eruditorg/static/sass/vars/_public.scss
@@ -71,11 +71,11 @@ $body-bg:               #fff;
 $text-color:            $gray-dark;
 
 //** Global textual link color.
-$link-color:            $gray-base;
+$link-color:            #000;
 //** Link hover color
-$link-hover-color:      $coral-red;
+$link-hover-color:      #000;
 //** Link hover decoration.
-$link-hover-decoration: underline;
+$link-hover-decoration: none;
 
 
 //== Typography

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -91,31 +91,119 @@
   <div class="container">
     <div class="row">
 
-      {# Journal information (on right side except mobile) #}
-      <aside class="col-sm-push-9 col-sm-3">
+      {% cache LONG_TTL "public_issue_detail_summary" issue.id LANGUAGE_CODE %}
+      {# Issue summary #}
+      <section class="col-sm-8">
+
+        <header class="page-header-main">
+            <p class="title-tag">{{ issue.journal.name }}</p>
+
+            <h1>
+              {% for theme in themes %}
+              {% if forloop.first %}<span>{% else %} / {% endif %}
+              {% if theme.html_name and theme.html_subname %}
+                {{ theme.html_name|safe }}: {{ theme.html_subname|safe }}
+              {% else %}
+                {{ theme.html_name|safe }}
+              {% endif %}
+              {% if forloop.first %}</span>{% endif %}
+              {% endfor %}
+              <span>{{ issue.volume_title_with_pages }}</span>
+            </h1>
+            <h2>{% trans "Sommaire" %} ({{ articles|length }} {% trans "articles" %})</h2>
+        </header>
+
+        {% if articles_per_section %}
+
+        {% for k, section1 in articles_per_section.items %}
+        {% if section1.titles.main %}
+        <h3 class="section">
+          {{ section1.titles.main }}
+          {% for paral in section1.titles.paral %}/ {{ paral }}{% endfor %}
+        </h3>
+        {% endif %}
+
+        <ol class="issue_detail--articles unstyled section-1">
+        {% for article in section1.objects %}
+        {% include "public/journal/partials/issue_detail_article_item.html" %}
+        {% endfor %}
+        </ol>
+
+        {% if section1.section2 %}
+          {% for k, section2 in section1.section2.items %}
+          {% if section2.titles.main %}
+          <h4 class="section">
+            {{ section2.titles.main }}
+            {% for paral in section2.titles.paral %}/ {{ paral }}{% endfor %}
+          </h4>
+          {% endif %}
+
+          <ol class="issue_detail--articles unstyled section-2">
+          {% for article in section2.objects %}
+          {% include "public/journal/partials/issue_detail_article_item.html" %}
+          {% endfor %}
+          </ol>
+
+          {% if section2.section3 %}
+            {% for k, section3 in section2.section3.items %}
+            {% if section3.titles.main %}
+            <h5 class="section">
+              {{ section3.titles.main }}
+              {% for paral in section3.titles.paral %}/ {{ paral }}{% endfor %}
+            </h5>
+            {% endif %}
+
+            <ol class="issue_detail--articles unstyled section-3">
+            {% for article in section3.objects %}
+            {% include "public/journal/partials/issue_detail_article_item.html" %}
+            {% endfor %}
+            </ol>
+
+            {% endfor %}
+          {% endif %}
+
+          {% endfor %}
+        {% endif %}
+
+        {% endfor %}
+
+        {% else %}
+
+          {# This is displayed only if the Fedora repository is unavailable #}
+
+          <ol class="issue_detail--articles unstyled section-1">
+          {% for article in articles %}
+          {% include "public/journal/partials/issue_detail_article_item.html" %}
+          {% endfor %}
+          </ol>
+
+        {% endif %}
+
+      </section>
+      {% endcache %}
+
+      {# Journal information #}
+      <aside class="col-sm-offset-1 col-sm-3 journal-meta">
         {% cache FOREVER_TTL "public_issue_detail_journal_info" issue.journal.id LANGUAGE_CODE %}
         <div class="sidebar-block clearfix issue_detail--resume">
+          <header>
+            <h2><a href="{% url 'public:journal:journal_detail' journal.code %}">{{ journal.name }}</a></h2>
+          </header>
 
           {% if issue.has_coverpage %}
           <div>
             <a href="{% url 'public:journal:journal_detail' journal.code %}">
               <img src="{% url 'public:journal:issue_coverpage' issue.journal.code issue.volume_slug issue.localidentifier %}" class="img-responsive" alt="{% trans 'Couverture de' %} {% if issue.html_title %}{{ issue.html_title|safe }}, {% endif %}
-              {{ issue.volume_title_with_pages }} {% trans 'de la revue' %} {{ journal.name }}" />
+              {{ issue.volume_title_with_pages }} {{ journal.name }}" />
             </a>
           </div>
           {% endif %}
 
-          <header>
-            <div class="mono-space">{% trans "De la revue" %}</div>
-            <h2 class="h4 no-margin"><a href="{% url 'public:journal:journal_detail' journal.code %}">{{ journal.name }}</a></h2>
-          </header>
-
         </div>
 
-        {# journal meta infos #}
-        <div class="sidebar-block journal-meta">
+        <div class="sidebar-block">
 
-          <h2>{% trans "Fiche" %}</h2>
+          <h3>{% trans "Fiche" %}</h3>
 
           <dl class="journal-meta--list">
 
@@ -199,7 +287,9 @@
             {% endif %}
           </dl>
           <div class="journal-meta--list">
-            <img src="{% url 'public:journal:journal_logo' journal.code %}" alt="" class="img-responsive journal_logo" />
+            <a href="{% url 'public:journal:journal_detail' journal.code %}">
+              <img src="{% url 'public:journal:journal_logo' journal.code %}" alt="" class="img-responsive journal_logo" />
+            </a>
           </div>
         </div>
         {% endcache %}
@@ -207,97 +297,6 @@
           {% include "public/partials/subscription_sponsor_badge.html" %}
         </div>
       </aside>
-
-      {% cache LONG_TTL "public_issue_detail_summary" issue.id LANGUAGE_CODE %}
-      {# Issue summary #}
-      <section class="col-sm-9 col-sm-pull-3">
-
-        <header class="page-header-main">
-            <p class="title-tag">{{ issue.journal.name }}</p>
-
-            <h1>
-              {% for theme in themes %}
-              {% if forloop.first %}<span>{% else %} / {% endif %}
-              {% if theme.html_name and theme.html_subname %}
-                {{ theme.html_name|safe }}: {{ theme.html_subname|safe }}
-              {% else %}
-                {{ theme.html_name|safe }}
-              {% endif %}
-              {% if forloop.first %}</span>{% endif %}
-              {% endfor %}
-              <span>{{ issue.volume_title_with_pages }}</span>
-            </h1>
-            <h2>{% trans "Sommaire" %} ({{ articles|length }} {% trans "articles" %})</h2>
-        </header>
-
-        {% if articles_per_section %}
-
-        {% for k, section1 in articles_per_section.items %}
-        {% if section1.titles.main %}
-        <h3 class="title-tag section">
-          {{ section1.titles.main }}
-          {% for paral in section1.titles.paral %}/ {{ paral }}{% endfor %}
-        </h3>
-        {% endif %}
-
-        <ol class="issue_detail--articles unstyled section-1">
-        {% for article in section1.objects %}
-        {% include "public/journal/partials/issue_detail_article_item.html" %}
-        {% endfor %}
-        </ol>
-
-        {% if section1.section2 %}
-          {% for k, section2 in section1.section2.items %}
-          {% if section2.titles.main %}
-          <h4 class="title-tag section">
-            {{ section2.titles.main }}
-            {% for paral in section2.titles.paral %}/ {{ paral }}{% endfor %}
-          </h4>
-          {% endif %}
-
-          <ol class="issue_detail--articles unstyled section-2">
-          {% for article in section2.objects %}
-          {% include "public/journal/partials/issue_detail_article_item.html" %}
-          {% endfor %}
-          </ol>
-
-          {% if section2.section3 %}
-            {% for k, section3 in section2.section3.items %}
-            {% if section3.titles.main %}
-            <h5 class="title-tag section">
-              {{ section3.titles.main }}
-              {% for paral in section3.titles.paral %}/ {{ paral }}{% endfor %}
-            </h5>
-            {% endif %}
-
-            <ol class="issue_detail--articles unstyled section-3">
-            {% for article in section3.objects %}
-            {% include "public/journal/partials/issue_detail_article_item.html" %}
-            {% endfor %}
-            </ol>
-
-            {% endfor %}
-          {% endif %}
-
-          {% endfor %}
-        {% endif %}
-
-        {% endfor %}
-
-        {% else %}
-
-          {# This is displayed only if the Fedora repository is unavailable #}
-
-          <ol class="issue_detail--articles unstyled section-1">
-          {% for article in articles %}
-          {% include "public/journal/partials/issue_detail_article_item.html" %}
-          {% endfor %}
-          </ol>
-
-        {% endif %}
-
-      </section>
-      {% endcache %}
 
     </div>
   </div>

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -309,44 +309,37 @@
 
   {% cache FOREVER_TTL "public_issue_detail_back_issues" issue.id LANGUAGE_CODE %}
   <section class="back-issues">
-
-      <div class="container">
-
-        <div class="row">
-
-          <header class="back-issues--header col-xs-12">
-            <h3 class="h2 no-margin">
-              {% trans "Anciens numéros de" %} <em>{{ journal.name }}</em><br/>
-              <small>({{ journal.published_issues|length }} numéros)</small>
-            </h3>
-          </header>
-
-        </div>
-
-        <div class="row">
-          <ul class="issue-list">
-            {% for published_issue in journal.published_issues|dictsortreversed:"year"|slice:":4" %}
-            {% if published_issue != issue %}
-            <li class="issue-list-item--inverted col-xs-6 col-sm-3">
-              <a href="{% url 'public:journal:issue_detail' published_issue.journal.code published_issue.volume_slug published_issue.localidentifier %}">
-                {% if issue.has_coverpage %}<img src="{% url 'public:journal:issue_coverpage' published_issue.journal.code published_issue.volume_slug published_issue.localidentifier %}" class="img-responsive" alt="{{ published_issue.name }}" />{% endif %}
-                <header>
-                  <h5>
-                    <a href="{% url 'public:journal:issue_detail' published_issue.journal.code published_issue.volume_slug published_issue.localidentifier %}">
-                      <span class="issue-list--volume">{% with title=published_issue.volume_title %}{{ title }}{% endwith %}</span>
-                      {% if published_issue.html_title %}<br/><span class="issue-list--theme">{{ published_issue.html_title|safe }}</span>{% endif %}
-                    </a>
-                  </h5>
-                </header>
-              </a>
-            </li>
-            {% endif %}
-            {% endfor %}
-          </ul>
-        </div>
-
-      </div>
-
+    <div class="container">
+      <header class="back-issues--header col-xs-12">
+        <h3>
+          {% trans "Anciens numéros de" %} <em>{{ journal.name }}</em><br/>
+          <a href="{% url 'public:journal:journal_detail' journal.code %}#back-issues">
+            <small>({{ journal.published_issues|length }} numéros)</small>
+          </a>
+        </h3>
+      </header>
+      <ul class="issue-list">
+        {% for published_issue in journal.published_issues|dictsortreversed:"year"|slice:":4" %}
+        {% if published_issue != issue %}
+        <li class="issue-list--item col-xs-6 col-sm-3">
+          {% if issue.has_coverpage %}
+          <a href="{% url 'public:journal:issue_detail' published_issue.journal.code published_issue.volume_slug published_issue.localidentifier %}">
+            <img src="{% url 'public:journal:issue_coverpage' published_issue.journal.code published_issue.volume_slug published_issue.localidentifier %}" class="img-responsive" alt="{{ published_issue.name }}" />
+          </a>
+          {% endif %}
+          <div class="issue-list--title">
+            <a href="{% url 'public:journal:issue_detail' published_issue.journal.code published_issue.volume_slug published_issue.localidentifier %}">
+              <h5>
+                <span class="issue-list--volume">{% with title=published_issue.volume_title %}{{ title }}{% endwith %}</span>
+                {% if published_issue.html_title %}<br/><span class="issue-list--theme">{{ published_issue.html_title|safe }}</span>{% endif %}
+              </h5>
+            </a>
+          </div>
+        </li>
+        {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
   </section>
   {% endcache %}
 

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -123,11 +123,13 @@
         </h3>
         {% endif %}
 
+        {% if section1.objects %}
         <ol class="issue_detail--articles unstyled section-1">
         {% for article in section1.objects %}
         {% include "public/journal/partials/issue_detail_article_item.html" %}
         {% endfor %}
         </ol>
+        {% endif %}
 
         {% if section1.section2 %}
           {% for k, section2 in section1.section2.items %}
@@ -138,11 +140,13 @@
           </h4>
           {% endif %}
 
+          {% if section2.objects %}
           <ol class="issue_detail--articles unstyled section-2">
           {% for article in section2.objects %}
           {% include "public/journal/partials/issue_detail_article_item.html" %}
           {% endfor %}
           </ol>
+          {% endif %}
 
           {% if section2.section3 %}
             {% for k, section3 in section2.section3.items %}
@@ -153,11 +157,13 @@
             </h5>
             {% endif %}
 
+            {% if section3.objects %}
             <ol class="issue_detail--articles unstyled section-3">
             {% for article in section3.objects %}
             {% include "public/journal/partials/issue_detail_article_item.html" %}
             {% endfor %}
             </ol>
+            {% endif %}
 
             {% endfor %}
           {% endif %}
@@ -266,9 +272,9 @@
 
             <dt class="mono-space">{% trans "Politique d'accès" %}</dt>
             {% if journal.open_access %}
-            <dd>{% trans "Disponible en libre accès" %}</dd>
+            <dd>{% trans "Disponible en libre accès" %} <span class="hint--top hint--no-animate" data-hint=""><span class="ion-help-circled"></span></span></dd>
             {% else %}
-            <dd>{% trans "Non-disponible en libre accès" %}</dd>
+            <dd>{% trans "Accès restreint" %} <span class="hint--top hint--no-animate" data-hint=""><span class="ion-help-circled"></span></span></dd>
             {% endif %}
 
             {% if journal.disciplines.all|length > 0 %}

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -93,7 +93,7 @@
 
       {% cache LONG_TTL "public_issue_detail_summary" issue.id LANGUAGE_CODE %}
       {# Issue summary #}
-      <section class="col-sm-8">
+      <section class="col-sm-9 col-md-8">
 
         <header class="page-header-main">
             <p class="title-tag">{{ issue.journal.name }}</p>
@@ -189,7 +189,7 @@
       {% endcache %}
 
       {# Journal information #}
-      <aside class="col-sm-offset-1 col-sm-3 journal-meta">
+      <aside class="col-sm-3 col-md-offset-1 col-md-3 journal-meta">
         {% cache FOREVER_TTL "public_issue_detail_journal_info" issue.journal.id LANGUAGE_CODE %}
         <div class="sidebar-block clearfix issue_detail--resume">
           <header>

--- a/eruditorg/templates/public/journal/journal_detail.html
+++ b/eruditorg/templates/public/journal/journal_detail.html
@@ -260,9 +260,9 @@
 
             <dt class="mono-space">{% trans "Politique d'accès" %}</dt>
             {% if journal.open_access %}
-            <dd>{% trans "Disponible en libre accès" %}</dd>
+            <dd>{% trans "Disponible en libre accès" %} <span class="hint--top hint--no-animate" data-hint=""><span class="ion-help-circled"></span></span></dd>
             {% else %}
-            <dd>{% trans "Non-disponible en libre accès" %}</dd>
+            <dd>{% trans "Accès restreint" %} <span class="hint--top hint--no-animate" data-hint=""><span class="ion-help-circled"></span></span></dd>
             {% endif %}
 
             {% if journal.disciplines.all|length > 0 %}

--- a/eruditorg/templates/public/journal/journal_detail.html
+++ b/eruditorg/templates/public/journal/journal_detail.html
@@ -314,9 +314,6 @@
 
       <div class="row">
         <header class="back-issues--header col-xs-12">
-          <div class="pull-right">
-            <a href="#" class="btn btn-primary-outlined">{% trans "Voir les numéros thématiques" %}</a>
-          </div>
           <h2>{% trans "Historique des numéros" %} ({{ issues|length }})</h2>
         </header>
       </div>

--- a/eruditorg/templates/public/journal/journal_detail.html
+++ b/eruditorg/templates/public/journal/journal_detail.html
@@ -68,16 +68,16 @@
     <div class="row">
 
       {# Journal about #}
-      <div id="journal-about" class="col-sm-9">
+      <div id="journal-about" class="col-sm-9 col-md-8">
         <header class="page-header-main row">
-          <div class="col-sm-9">
+          <div class="col-sm-12">
             <h1>
               <span>{{ journal.name }}</span>
               {% if journal.subtitle %}<span>{{ journal.subtitle }}</span>{% endif %}
             </h1>
-          </div>
-          <div class="col-sm-3 text-right">
-            <a href="{% url 'public:journal:journal_authors_list' journal.code %}" class="btn btn-primary-outlined">{% trans "Index des auteurs" %}</a>
+            <p class="text-right">
+              <a href="{% url 'public:journal:journal_authors_list' journal.code %}">{% trans "Index des auteurs" %}</a>
+            <p>
           </div>
         </header>
 
@@ -164,8 +164,8 @@
       </div>
 
 
-      {# Journal information (on right side except mobile) #}
-      <aside id="journal-meta" class="journal-meta col-sm-3">
+      {# Journal information #}
+      <aside id="journal-meta" class="col-sm-3 col-md-offset-1 col-md-3 journal-meta">
 
         {# lastest issue #}
         {% if latest_issue %}

--- a/eruditorg/templates/public/journal/journal_list_per_disciplines.html
+++ b/eruditorg/templates/public/journal/journal_list_per_disciplines.html
@@ -111,9 +111,6 @@
                   {% if journal.subtitle %}
                   <p class="color-dark-grey">{{ journal.subtitle }}</p>
                   {% endif %}
-                  {% if journal.type.code == 'S' %}
-                  <p class="bold">{% trans "Révisé par les pairs" %}</p>
-                  {% endif %}
                 </div>
                 <div class="col-xs-4">
                   {% if journal.provided_by_fedora %}

--- a/eruditorg/templates/public/journal/journal_list_per_names.html
+++ b/eruditorg/templates/public/journal/journal_list_per_names.html
@@ -128,9 +128,6 @@
                   {% if journal.subtitle %}
                   <p class="color-dark-grey">{{ journal.subtitle }}</p>
                   {% endif %}
-                  {% if journal.type.code == 'S' %}
-                  <p class="bold">{% trans "Révisé par les pairs" %}</p>
-                  {% endif %}
                 </div>
               </div>
               <div class="col-sm-2">

--- a/eruditorg/templates/public/journal/partials/issue_detail_article_item.html
+++ b/eruditorg/templates/public/journal/partials/issue_detail_article_item.html
@@ -2,26 +2,30 @@
 {% load cache %}
 
 {% cache FOREVER_TTL "public_issue_detail_articles_item" article.id LANGUAGE_CODE %}
-<li class="issue_detail--article-item">
+<li class="article-item">
   <div class="toolbox pull-right">
     {% spaceless %}
     <a href="#" title="{% trans 'Sauvegarder' %}" data-citation-save="#article-{{ article.id }}"><span class="erudicon erudicon-tools-save"></span></a>
     <a href="#" title="{% trans 'Supprimer' %}" data-citation-remove="#article-{{ article.id }}" class="saved"><span class="erudicon erudicon-tools-save"></span></a>
-    <a href="" title="{% trans 'Télécharger' %}" target="_blank"><span class="erudicon erudicon-tools-pdf"></span></a>
+    <a href="{% url 'public:journal:article_raw_pdf' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}" title="{% trans 'Télécharger' %}" target="_blank"><span class="erudicon erudicon-tools-pdf"></span></a>
     {% endspaceless %}
   </div>
   <h6 class="article-title">
     <a href="{% if article.external_url %}{% url 'public:journal:article_external_redirect' article.localidentifier %}{% else %}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}{% endif %}">{{ article.html_title|safe|default:article.title }}</a>
   </h6>
-  <p class="issue_detail--article-item--author">{{ article.authors.all|join:", " }}</p>
-  <div class="mono-space">
-    {% with first_page=article.first_page last_page=article.last_page %}
-    {% if first_page and last_page and first_page != last_page %}
-    {% blocktrans trimmed with first_page=first_page last_page=last_page %}pp.&nbsp;{{ first_page }}–{{ last_page }}{% endblocktrans %}
-    {% elif first_page and first_page != "0" %}
-    {% blocktrans trimmed with page=first_page %}p.&nbsp;{{ page }}{% endblocktrans %}
-    {% endif %}
-    {% endwith %}
+  <div class="article-metadata row">
+    <p class="article-author col-sm-9">
+      {{ article.authors.all|join:", " }}
+    </p>
+    <p class="article-pagination col-sm-3">
+      {% with first_page=article.first_page last_page=article.last_page %}
+      {% if first_page and last_page and first_page != last_page %}
+      {% blocktrans trimmed with first_page=first_page last_page=last_page %}pp.&nbsp;{{ first_page }}–{{ last_page }}{% endblocktrans %}
+      {% elif first_page and first_page != "0" %}
+      {% blocktrans trimmed with page=first_page %}p.&nbsp;{{ page }}{% endblocktrans %}
+      {% endif %}
+      {% endwith %}
+    </p>
   </div>
 </li>
 {% endcache %}

--- a/eruditorg/templates/public/journal/partials/issue_detail_article_item.html
+++ b/eruditorg/templates/public/journal/partials/issue_detail_article_item.html
@@ -3,12 +3,18 @@
 
 {% cache FOREVER_TTL "public_issue_detail_articles_item" article.id LANGUAGE_CODE %}
 <li class="issue_detail--article-item">
-  <h6><a href="{% if article.external_url %}{% url 'public:journal:article_external_redirect' article.localidentifier %}{% else %}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}{% endif %}">{{ article.html_title|safe|default:article.title }}</a></h6>
+  <div class="toolbox pull-right">
+    {% spaceless %}
+    <a href="#" title="{% trans 'Sauvegarder' %}" data-citation-save="#article-{{ article.id }}"><span class="erudicon erudicon-tools-save"></span></a>
+    <a href="#" title="{% trans 'Supprimer' %}" data-citation-remove="#article-{{ article.id }}" class="saved"><span class="erudicon erudicon-tools-save"></span></a>
+    <a href="" title="{% trans 'Télécharger' %}" target="_blank"><span class="erudicon erudicon-tools-pdf"></span></a>
+    {% endspaceless %}
+  </div>
+  <h6 class="article-title">
+    <a href="{% if article.external_url %}{% url 'public:journal:article_external_redirect' article.localidentifier %}{% else %}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}{% endif %}">{{ article.html_title|safe|default:article.title }}</a>
+  </h6>
   <p class="issue_detail--article-item--author">{{ article.authors.all|join:", " }}</p>
   <div class="mono-space">
-    <a href="{% if article.external_url %}{% url 'public:journal:article_external_redirect' article.localidentifier %}{% else %}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}{% endif %}" class="btn btn-primary-outlined">{% trans "HTML" %}</a>
-    <a href="#" class="btn btn-primary-outlined" data-citation-save="#article-{{ article.id }}">{% trans "Sauvegarder" %}</a>
-    <a href="#" class="btn btn-primary-outlined" data-citation-remove="#article-{{ article.id }}">{% trans "Supprimer" %}</a>
     {% with first_page=article.first_page last_page=article.last_page %}
     {% if first_page and last_page and first_page != last_page %}
     {% blocktrans trimmed with first_page=first_page last_page=last_page %}pp.&nbsp;{{ first_page }}–{{ last_page }}{% endblocktrans %}

--- a/eruditorg/templates/public/search/advanced_search.html
+++ b/eruditorg/templates/public/search/advanced_search.html
@@ -10,11 +10,10 @@
   <section id="advanced-search-page" class="container">
 
     <div class="row">
-      <header class="page-header-main search-header col-xs-12 border-bottom">
-        <hgroup>
-          <h2>{% trans "Recherche avancée" %} <span class="hint--top hint--no-animate" data-hint="{% trans "La recherche avancée vous permet de définir avec précision les requêtes de recherche à exécuter au sein de la base de données des documents Érudit" %}"><i class="ion-help-circled"></i></span></h2>
-        </hgroup>
-      </header>
+      <div class="page-header-main search-header col-md-8">
+        <h2>{% trans "Recherche avancée" %}</h2>
+        {% lorem 1 p %}
+      </div>
     </div>
 
     <form action="{% url 'public:search:results' %}" id="id_search" class="advanced-search-form" method="get">


### PR DESCRIPTION
Re-style according to new mockups (with section and subsection titles), improve mobile and accessibility, uniformise with journal detail 

- [Short summary, no section titles](http://127.0.0.1:8000/fr/revues/pv/2013-v12-n1-pv01421/) - [Current](http://www.erudit.org/revue/pv/2013/v12/n1/index.html)
- [Short summary, one level](http://127.0.0.1:8000/fr/revues/ae/2014-v90-n3-ae02325/) - [Current](https://www.erudit.org/revue/ae/2014/v90/n3/index.html)
- [Mid-sized summary, one level and articles without a section title](http://localhost:8000/fr/revues/ateliers/2015-v10-n2-ateliers02386/) - [Current](https://www.erudit.org/revue/ateliers/2015/v10/n2/index.html)
- [Long summary, two levels](http://127.0.0.1:8000/fr/revues/rabaska/2015-v13-rabaska02149/) - [Current](https://www.erudit.org/revue/rabaska/2015/v13/n/index.html)
- [Long summary, three levels (Place publique > Points de vue > Revue)](http://localhost:8000/fr/revues/rabaska/2011-v9-rabaska1819335/) - [Current](https://www.erudit.org/revue/rabaska/2011/v9/n/index.html)