### PR TITLE
search: support non-fedora articles with no pdf

### DIFF
--- a/eruditorg/apps/public/search/serializers.py
+++ b/eruditorg/apps/public/search/serializers.py
@@ -105,7 +105,8 @@ class ArticleSerializer(serializers.ModelSerializer):
 
     def get_has_pdf(self, obj):
         try:
-            return obj.external_pdf_url is not None or obj.fedora_object.pdf.exists
+            return obj.external_pdf_url is not None or (
+                obj.fedora_object and obj.fedora_object.pdf.exists)
         except (RequestFailed, ConnectionError):  # pragma: no cover
             if settings.DEBUG:
                 return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.9.9
-git+https://github.com/erudit/erudit-core.git@0.2.8#egg=erudit-core
+git+https://github.com/erudit/erudit-core.git@0.2.10#egg=erudit-core
 git+https://github.com/erudit/django-resumable-uploads.git@master#egg=django-resumable-uploads
 git+https://github.com/erudit/django-account-actions.git@master#egg=django-account-actions
 eulxml==1.0.1

--- a/tests/functional/apps/public/journal/test_views.py
+++ b/tests/functional/apps/public/journal/test_views.py
@@ -165,7 +165,7 @@ class TestJournalDetailView(BaseEruditTestCase):
 
     def test_can_embed_the_publicated_issues_in_the_context(self):
         # Setup
-        collection = CollectionFactory.create()
+        collection = CollectionFactory.create(localidentifier='erudit')
         journal = JournalFactory.create(collection=collection)
         JournalInformationFactory.create(journal=journal)
         issue_1 = IssueFactory.create(
@@ -183,7 +183,7 @@ class TestJournalDetailView(BaseEruditTestCase):
 
     def test_can_embed_the_latest_issue_in_the_context(self):
         # Setup
-        collection = CollectionFactory.create()
+        collection = CollectionFactory.create(localidentifier='erudit')
         journal = JournalFactory.create(collection=collection)
         JournalInformationFactory.create(journal=journal)
         IssueFactory.create(


### PR DESCRIPTION
Test that an article has a fedora_object before testing
for an external pdf.

ref #2021