### PR TITLE
Remove tags from breadcrumbs

### DIFF
--- a/eruditorg/templates/public/journal/article_detail.html
+++ b/eruditorg/templates/public/journal/article_detail.html
@@ -124,7 +124,7 @@
   / <a href="{% url 'public:journal:journal_detail' article.issue.journal.code %}">{{ article.issue.journal.name }}</a>
   / <a href="{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}">
    {% if article.issue.html_title %}
-   {{ article.issue.html_title|safe|truncatechars:50 }}
+   {{ article.issue.html_title|striptags|safe|truncatechars:50 }}
    {% else %}
    {{ article.issue.volume_title_with_pages }}
    {% endif %}

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -69,7 +69,7 @@
   / <a href="{% url 'public:journal:journal_detail' journal.code %}">{{ issue.journal.name }}</a>
   / <a href="{% url 'public:journal:issue_detail' issue.journal.code issue.volume_slug issue.localidentifier %}">
     {% if issue.html_title %}
-    {{ issue.html_title|safe|truncatechars_html:50 }}
+    {{ issue.html_title|striptags|safe|truncatechars_html:50 }}
     {% else %}
     {{ issue.volume_title_with_pages }}
     {% endif %}


### PR DESCRIPTION
Long issue or article titles are often truncated in breadcrumbs. Many contain emphases or other markup and result in [unclosed tags](http://preprod.erudit.org/fr/revues/ref/2010-v16-n2-ref1493790/1000321ar/). Remove all tags (`<em>`, ...) as they are not necessary for breadcrumbs. 