### PR TITLE
#1488 - References as tooltips

### DIFF
--- a/eruditorg/static/js/controllers/public/journal/ArticleDetailController.js
+++ b/eruditorg/static/js/controllers/public/journal/ArticleDetailController.js
@@ -52,7 +52,7 @@ export default {
   },
 
   smooth_scroll : function () {
-    this.article.find('.article-table-of-contents').on('click', 'a', (e) => {
+    this.article.on('click', 'a[href*="#"]', (e) => {
       if( e ) {
         e.preventDefault();
         e.stopPropagation();
@@ -76,11 +76,11 @@ export default {
       clipboard.copy( $(e.currentTarget).attr('href') ).then(
         () => {
           $(e.currentTarget).addClass('success');
-          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
+          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
         },
         () => {
           $(e.currentTarget).addClass('error');
-          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
+          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
         }
       );
       return false;

--- a/eruditorg/static/sass/components/_tooltips.scss
+++ b/eruditorg/static/sass/components/_tooltips.scss
@@ -23,4 +23,6 @@
   vertical-align: top;
   padding: 4px;
   @include border-radius(11px);
+  @include fw-sans;
+  font-size: 12px;
 }

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1892,7 +1892,9 @@
         <xsl:attribute name="data-hint">
           <xsl:variable name="idref" select="@idref"/>
           <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)], 1, 200)"/>
-          <xsl:text>[…]</xsl:text>
+          <xsl:if test="string-length(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)]) &gt; 200">
+            <xsl:text>[…]</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <xsl:text>[</xsl:text>
         <xsl:value-of select="normalize-space()"/>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1877,11 +1877,24 @@
   </xsl:template>
   <xsl:template match="renvoi">
       <xsl:text>&#160;</xsl:text>
-      <a href="#{@idref}" id="{@id}" class="norenvoi">
-          <xsl:text>[</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>]</xsl:text>
-      </a>
+      <xsl:element name="a">
+        <xsl:attribute name="href">
+          <xsl:text>#</xsl:text><xsl:value-of select="@idref"/>
+        </xsl:attribute>
+        <xsl:attribute name="id">
+          <xsl:value-of select="@id"/>
+        </xsl:attribute>
+        <xsl:attribute name="class">
+          <xsl:text>norenvoi hint--bottom hint--no-animate</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="data-hint">
+          <xsl:variable name="idref" select="@idref"/>
+          <xsl:value-of select="/article/partiesann/grnote/note[@id=$idref]/alinea"/>
+        </xsl:attribute>
+        <xsl:text>[</xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text>]</xsl:text>
+      </xsl:element>
   </xsl:template>
 
   <xsl:template match="notefig|notetabl">

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -108,6 +108,7 @@
 							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
 						</a>
 					</dd>
+          {% if not article.issue.journal.type.code == 'C' %}
 					<dt>DOI</dt>
 					<dd>
 						<a href="{$doiStart}10.7202/{$iderudit}" class="clipboard-data">
@@ -116,6 +117,7 @@
 							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
 						</a>
 					</dd>
+          {% endif %}
 				</dl>
 
         <xsl:apply-templates select="liminaire/notegen"/>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1889,7 +1889,7 @@
         </xsl:attribute>
         <xsl:attribute name="data-hint">
           <xsl:variable name="idref" select="@idref"/>
-          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/alinea, 1, 200)"/>
+          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)], 1, 200)"/>
           <xsl:text>[…]</xsl:text>
         </xsl:attribute>
         <xsl:text>[</xsl:text>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1889,7 +1889,8 @@
         </xsl:attribute>
         <xsl:attribute name="data-hint">
           <xsl:variable name="idref" select="@idref"/>
-          <xsl:value-of select="/article/partiesann/grnote/note[@id=$idref]/alinea"/>
+          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/alinea, 1, 200)"/>
+          <xsl:text>[…]</xsl:text>
         </xsl:attribute>
         <xsl:text>[</xsl:text>
         <xsl:apply-templates/>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1893,7 +1893,7 @@
           <xsl:text>[…]</xsl:text>
         </xsl:attribute>
         <xsl:text>[</xsl:text>
-        <xsl:apply-templates/>
+        <xsl:value-of select="normalize-space()"/>
         <xsl:text>]</xsl:text>
       </xsl:element>
   </xsl:template>


### PR DESCRIPTION
* Display all reference notes as tooltips, scroll to full note on click
* Do not display DOI for cultural articles
* Smooth scroll for all links

# Examples

## Scholarly articles with references ([1], [2]...)
* [Urban Environments and the Animal Nuisance: Domestic Livestock Regulation in Nineteenth-Century Canadian Cities](http://127.0.0.1:8000/fr/revues/uhr/2015-v44-n1-2-uhr02614/1037235ar/#re1no1)
* [Liquidité du marché des actions et rendements des fonds mutuels en temps de crise : évidence canadienne](http://127.0.0.1:8000/fr/revues/ae/2015-v91-n4-ae02612/1037207ar/)
* [L’écriture de Nietzsche dans Zarathoustra](http://127.0.0.1:8000/fr/revues/philoso/2011-v38-n2-philoso1829729/1007457ar/)

## Cultural articles (no DOIs)
* [Brochet & Tremblay, distributeur en alimentation](http://127.0.0.1:8000/fr/revues/mgaspesie/2016-v53-n2-mgaspesie02609/82780ac/)
* [La règle du jeu](http://127.0.0.1:8000/fr/revues/images/2016-n178-images02611/82794ac/)
* [Manipulations syntaxiques](http://127.0.0.1:8000/fr/revues/xyz/2016-n127-xyz02606/82735ac/)