### PR TITLE
#1488 & #1489 - References in tooltips, DOI / URI

### DIFF
--- a/eruditorg/static/js/controllers/public/journal/ArticleDetailController.js
+++ b/eruditorg/static/js/controllers/public/journal/ArticleDetailController.js
@@ -52,7 +52,7 @@ export default {
   },
 
   smooth_scroll : function () {
-    this.article.find('.article-table-of-contents').on('click', 'a', (e) => {
+    this.article.on('click', 'a[href*="#"]', (e) => {
       if( e ) {
         e.preventDefault();
         e.stopPropagation();
@@ -76,11 +76,11 @@ export default {
       clipboard.copy( $(e.currentTarget).attr('href') ).then(
         () => {
           $(e.currentTarget).addClass('success');
-          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
+          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
         },
         () => {
           $(e.currentTarget).addClass('error');
-          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
+          setTimeout(() => { $(e.currentTarget).removeClass('success error'); }, 3000);
         }
       );
       return false;

--- a/eruditorg/static/sass/components/_lists.scss
+++ b/eruditorg/static/sass/components/_lists.scss
@@ -52,6 +52,7 @@ dl {
   }
 
   dt {
+    margin-right: 0.5em;
     float: left;
     clear: left;
     font-weight: normal;

--- a/eruditorg/static/sass/components/_tooltips.scss
+++ b/eruditorg/static/sass/components/_tooltips.scss
@@ -23,4 +23,6 @@
   vertical-align: top;
   padding: 4px;
   @include border-radius(11px);
+  @include fw-sans;
+  font-size: 12px;
 }

--- a/eruditorg/static/sass/pages/_article-detail.scss
+++ b/eruditorg/static/sass/pages/_article-detail.scss
@@ -194,6 +194,7 @@ $article-toolbar-width: 80px;
         .clipboard-msg {
           position: absolute;
           left: 0;
+          top: 0;
           width: 100%;
           height: 100%;
           text-align: center;

--- a/eruditorg/static/sass/pages/_journal-list-names.scss
+++ b/eruditorg/static/sass/pages/_journal-list-names.scss
@@ -17,6 +17,10 @@
           padding: 0 0 0.15em 0;
         }
 
+        [class*="hint--"]:after {
+          width: 150px;
+        }
+
         .form-group {
           margin: 0 0 2em 0;
           padding: 0;

--- a/eruditorg/static/sass/pages/_journal-list-names.scss
+++ b/eruditorg/static/sass/pages/_journal-list-names.scss
@@ -17,8 +17,13 @@
           padding: 0 0 0.15em 0;
         }
 
-        [class*="hint--"]:after {
-          width: 150px;
+        [class*="hint--"] {
+          float: right;
+
+          &:after {
+            width: 150px;
+          }
+
         }
 
         .form-group {

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1892,7 +1892,9 @@
         <xsl:attribute name="data-hint">
           <xsl:variable name="idref" select="@idref"/>
           <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)], 1, 200)"/>
-          <xsl:text>[…]</xsl:text>
+          <xsl:if test="string-length(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)]) &gt; 200">
+            <xsl:text>[…]</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <xsl:text>[</xsl:text>
         <xsl:value-of select="normalize-space()"/>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1877,11 +1877,24 @@
   </xsl:template>
   <xsl:template match="renvoi">
       <xsl:text>&#160;</xsl:text>
-      <a href="#{@idref}" id="{@id}" class="norenvoi">
-          <xsl:text>[</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>]</xsl:text>
-      </a>
+      <xsl:element name="a">
+        <xsl:attribute name="href">
+          <xsl:text>#</xsl:text><xsl:value-of select="@idref"/>
+        </xsl:attribute>
+        <xsl:attribute name="id">
+          <xsl:value-of select="@id"/>
+        </xsl:attribute>
+        <xsl:attribute name="class">
+          <xsl:text>norenvoi hint--bottom hint--no-animate</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="data-hint">
+          <xsl:variable name="idref" select="@idref"/>
+          <xsl:value-of select="/article/partiesann/grnote/note[@id=$idref]/alinea"/>
+        </xsl:attribute>
+        <xsl:text>[</xsl:text>
+        <xsl:apply-templates/>
+        <xsl:text>]</xsl:text>
+      </xsl:element>
   </xsl:template>
 
   <xsl:template match="notefig|notetabl">

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -108,6 +108,7 @@
 							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
 						</a>
 					</dd>
+          {% if not article.issue.journal.type.code == 'C' %}
 					<dt>DOI</dt>
 					<dd>
 						<a href="{$doiStart}10.7202/{$iderudit}" class="clipboard-data">
@@ -116,6 +117,7 @@
 							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
 						</a>
 					</dd>
+          {% endif %}
 				</dl>
 
         <xsl:apply-templates select="liminaire/notegen"/>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -102,20 +102,24 @@
 				<dl class="mono-space idpublic">
 					<dt>URI</dt>
 					<dd>
-						<a href="{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}" class="clipboard-data">
-							{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}
-							<span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
-							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
-						</a>
+            <span class="hint--top hint--no-animate" data-hint="{% blocktrans %}Cliquez pour copier l'URI de cet article.{% endblocktrans %}">
+  						<a href="{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}" class="clipboard-data">
+  							{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}
+  							<span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
+  							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
+  						</a>
+            </span>
 					</dd>
           {% if not article.issue.journal.type.code == 'C' %}
 					<dt>DOI</dt>
 					<dd>
-						<a href="{$doiStart}10.7202/{$iderudit}" class="clipboard-data">
-							10.7202/<xsl:value-of select="$iderudit"/>
-							<span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
-							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
-						</a>
+            <span class="hint--top hint--no-animate" data-hint="{% blocktrans %}Cliquez pour copier le DOI de cet article.{% endblocktrans %}">
+  						<a href="{$doiStart}10.7202/{$iderudit}" class="clipboard-data">
+  							10.7202/<xsl:value-of select="$iderudit"/>
+  							<span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
+  							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
+  						</a>
+            </span>
 					</dd>
           {% endif %}
 				</dl>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1889,7 +1889,7 @@
         </xsl:attribute>
         <xsl:attribute name="data-hint">
           <xsl:variable name="idref" select="@idref"/>
-          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/alinea, 1, 200)"/>
+          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)], 1, 200)"/>
           <xsl:text>[…]</xsl:text>
         </xsl:attribute>
         <xsl:text>[</xsl:text>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1889,7 +1889,8 @@
         </xsl:attribute>
         <xsl:attribute name="data-hint">
           <xsl:variable name="idref" select="@idref"/>
-          <xsl:value-of select="/article/partiesann/grnote/note[@id=$idref]/alinea"/>
+          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/alinea, 1, 200)"/>
+          <xsl:text>[…]</xsl:text>
         </xsl:attribute>
         <xsl:text>[</xsl:text>
         <xsl:apply-templates/>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1893,7 +1893,7 @@
           <xsl:text>[…]</xsl:text>
         </xsl:attribute>
         <xsl:text>[</xsl:text>
-        <xsl:apply-templates/>
+        <xsl:value-of select="normalize-space()"/>
         <xsl:text>]</xsl:text>
       </xsl:element>
   </xsl:template>

--- a/eruditorg/templates/public/journal/journal_list_per_names.html
+++ b/eruditorg/templates/public/journal/journal_list_per_names.html
@@ -84,7 +84,7 @@
               </div>
 
               <div id="div_id_{{ filter_form.types.html_name }}" class="form-group">
-                <h3>{{ filter_form.types.label }}&nbsp;<span class="hint--bottom hint--no-animate" data-hint="{% trans 'Les revues savantes publient des articles scientifiques révisés par les pairs&nbsp;; les revues culturelles présentent des articles dans les domaines artistique, littéraire et socioculturel. ' %}"><span class="ion-help-circled"></span></span></h3>
+                <h3>{{ filter_form.types.label }}&nbsp;<span class="hint--bottom-left hint--no-animate" data-hint="{% trans 'Les revues savantes publient des articles scientifiques révisés par les pairs&nbsp;; les revues culturelles présentent des articles dans les domaines artistique, littéraire et socioculturel. ' %}"><span class="ion-help-circled"></span></span></h3>
                 <div class="controls">
                   {% for choice in filter_form.types.field.choices %}
                   <div class="checkbox">
@@ -96,7 +96,7 @@
               </div>
 
               <div id="div_id_{{ filter_form.collections.html_name }}" class="form-group">
-                <h3>{{ filter_form.collections.label }}&nbsp;<span class="hint--bottom hint--no-animate" data-hint="{% trans 'Les revues diffusées sur Érudit sont consultables directement sur la plateforme&nbsp;; les revues des collections Persée et NRC Research Press redirigent vers la plateforme du partenaire.' %}"><span class="ion-help-circled"></span></span></h3>
+                <h3>{{ filter_form.collections.label }}&nbsp;<span class="hint--bottom-left hint--no-animate" data-hint="{% trans 'Les revues diffusées sur Érudit sont consultables directement sur la plateforme&nbsp;; les revues des collections Persée et NRC Research Press redirigent vers la plateforme du partenaire.' %}"><span class="ion-help-circled"></span></span></h3>
                 <div class="controls">
                   {% for choice in filter_form.collections.field.choices %}
                   <div class="checkbox">


### PR DESCRIPTION
* Display all reference notes as tooltips, scroll to full note on click
* Do not display DOI for cultural articles
* Improve DOI / URI copy to clipboard display

# Examples

## Scholarly articles with references ([1], [2]...)
* [Urban Environments and the Animal Nuisance: Domestic Livestock Regulation in Nineteenth-Century Canadian Cities](http://127.0.0.1:8000/fr/revues/uhr/2015-v44-n1-2-uhr02614/1037235ar/#re1no1)
* [Liquidité du marché des actions et rendements des fonds mutuels en temps de crise : évidence canadienne](http://127.0.0.1:8000/fr/revues/ae/2015-v91-n4-ae02612/1037207ar/)
* [L’écriture de Nietzsche dans Zarathoustra](http://127.0.0.1:8000/fr/revues/philoso/2011-v38-n2-philoso1829729/1007457ar/)

## Cultural articles (no DOIs)
* [Brochet & Tremblay, distributeur en alimentation](http://127.0.0.1:8000/fr/revues/mgaspesie/2016-v53-n2-mgaspesie02609/82780ac/)
* [La règle du jeu](http://127.0.0.1:8000/fr/revues/images/2016-n178-images02611/82794ac/)
* [Manipulations syntaxiques](http://127.0.0.1:8000/fr/revues/xyz/2016-n127-xyz02606/82735ac/)