### PR TITLE
#2328 - Fix copy

### DIFF
--- a/eruditorg/templates/public/base.html
+++ b/eruditorg/templates/public/base.html
@@ -115,7 +115,7 @@
           </li>
           {% endif %}
           <li class="hidden-sm">
-            <a href="{% url 'public:search:advanced_search' %}" class="main-section" title="{% trans 'Effectuer une recherche avancée' %}">Recherche avancée</a>
+            <a href="{% url 'public:search:advanced_search' %}" class="main-section" title="{% trans 'Effectuer une recherche avancée' %}">{% trans "Recherche avancée" %}</a>
           </li>
           <li>
             <a href="{% url 'public:citations:list' %}" title="{% trans 'Voir ma bibliothèque' %}">

--- a/eruditorg/templates/public/home.html
+++ b/eruditorg/templates/public/home.html
@@ -64,7 +64,7 @@
         <div class="col-xs-12 col-sm-4 glory--search">
           <form action="{% url 'public:search:results' %}" id="id-search" method="get">
             <div class="form-group">
-              <label for="basic-search" class="h3">Recherche</label>
+              <label for="basic-search" class="h3">{% trans "Recherche" %}</label>
               <div class="input-group">
                 <input name="basic_search_term" id="basic-search" type="search" class="form-control" placeholder="{% trans "Par auteur, titre, mots-clés&hellip;" %}" autofocus>
                 <div class="input-group-addon">

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -147,9 +147,9 @@
 
 		</header>
 
-		<div id="article-content" class="row border-top">
-			<xsl:if test="//corps">
-				{% if article.issue.journal.type.code == 'S' or article.erudit_object.processing == 'complet' %}
+    <div id="article-content" class="row border-top">
+      <xsl:if test="//corps">
+        {% if article.erudit_object.processing == 'complet' %}
         <!-- article outline -->
         <nav class="hidden-xs hidden-sm hidden-md col-md-3 article-table-of-contents" role="navigation">
           <h2>{% trans "Plan de l’article" %}</h2>
@@ -164,7 +164,7 @@
                 <a href="#resume">{% trans "Résumé" %}</a>
               </li>
             </xsl:if>
-			{% if article_access_granted and not only_summary %}
+            {% if article_access_granted and not only_summary %}
             <xsl:if test="//section1/titre[not(@traitementparticulier='oui')]">
               <li class="article-toc--body">
                 <ul class="unstyled">
@@ -172,7 +172,7 @@
                 </ul>
               </li>
             </xsl:if>
-			{% endif %}
+            {% endif %}
             <xsl:for-each select="partiesann[1]">
               <xsl:if test="grannexe">
                 <li>
@@ -222,7 +222,7 @@
             </xsl:if>
           </ul>
         </nav>
-				{% endif %}
+        {% endif %}
 
         <!-- toolbox -->
         <aside class="pull-right toolbox hidden-xs hidden-sm">
@@ -238,43 +238,43 @@
                 <span class="tools-label">{% trans "Supprimer" %}</span>
               </button>
             </li>
-			{% if article_access_granted and article.fedora_object.pdf.exists %}
+            {% if article_access_granted and article.fedora_object.pdf.exists %}
             <li>
               <button id="tool-download" data-href="{% url 'public:journal:article_raw_pdf' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">
                 <span class="erudicon erudicon-tools-pdf"></span>
                 <span class="tools-label">{% trans "Télécharger" %}</span>
               </button>
             </li>
-			{% endif %}
+            {% endif %}
             <li>
               <button id="tool-cite" data-modal-id="#id_cite_modal_{{ article.id }}">
                 <span class="erudicon erudicon-tools-cite"></span>
-				<span class="tools-label">{% trans "Citer cet article" %}</span>
-			</button>
-			</li>
-						<li>
-							<button id="tool-share" data-title="{{ article.title }}" data-cite="#id_cite_mla_{{ article.id }}">
-								<span class="erudicon erudicon-tools-share"></span>
-								<span class="tools-label">{% trans "Partager" %}</span>
-							</button>
-						</li>
-						<li>
-							<button id="tool-print">
-								<span class="erudicon erudicon-tools-print"></span>
-								<span class="tools-label">{% trans "Imprimer" %}</span>
-							</button>
-						</li>
-						<li>
-							<button id="tool-fullscreen">
-								<span class="erudicon erudicon-tools-fullscreen"></span>
-								<span class="tools-label">{% trans "Mode zen" %}</span>
-							</button>
-						</li>
-					</ul>
-				</aside>
-			</xsl:if>
+                <span class="tools-label">{% trans "Citer cet article" %}</span>
+              </button>
+            </li>
+            <li>
+              <button id="tool-share" data-title="{{ article.title }}" data-cite="#id_cite_mla_{{ article.id }}">
+                <span class="erudicon erudicon-tools-share"></span>
+                <span class="tools-label">{% trans "Partager" %}</span>
+              </button>
+            </li>
+            <li>
+              <button id="tool-print">
+                <span class="erudicon erudicon-tools-print"></span>
+                <span class="tools-label">{% trans "Imprimer" %}</span>
+              </button>
+            </li>
+            <li>
+              <button id="tool-fullscreen">
+                <span class="erudicon erudicon-tools-fullscreen"></span>
+                <span class="tools-label">{% trans "Mode zen" %}</span>
+              </button>
+            </li>
+          </ul>
+        </aside>
+      </xsl:if>
 
-      <div class="full-article {% if article.issue.journal.type.code == 'S' or article.erudit_object.processing == 'complet' %}col-md-7 col-md-offset-1{% else %}col-md-11{% endif %}">
+      <div class="full-article {% if article.erudit_object.processing == 'complet' %}col-md-7 col-md-offset-1{% else %}col-md-11{% endif %}">
 
         {% if not article_access_granted and not only_summary %}
         <div class="alert alert-warning">
@@ -294,21 +294,21 @@
 				</section>
 				</xsl:if>
 
-				{% if article_access_granted and not only_summary %}
-					{% if article.erudit_object.processing == 'complet' %}
-					<!-- body -->
-					<section id="corps" class="article-section corps" role="main">
-	          <h2 class="hidden">{% trans "Corps de l’article" %}</h2>
-						<xsl:apply-templates select="//corps"/>
-					</section>
-					{% elif article.localidentifier %}
-					<object data="{% url 'public:journal:article_raw_pdf' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}?embed" type="application/pdf" width="100%" height="700px"></object>
-					{% endif %}
-				{% elif not article.erudit_object.abstracts %}
-					<p>
-						{{ article.erudit_object.html_body|safe|truncatewords_html:600 }}
-					</p>
-				{% endif %}
+        {% if article_access_granted and not only_summary %}
+        {% if article.erudit_object.processing == 'complet' %}
+        <!-- body -->
+        <section id="corps" class="article-section corps" role="main">
+          <h2 class="hidden">{% trans "Corps de l’article" %}</h2>
+          <xsl:apply-templates select="//corps"/>
+        </section>
+        {% elif article.localidentifier %}
+        <object data="{% url 'public:journal:article_raw_pdf' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}?embed" type="application/pdf" width="100%" height="700px"></object>
+        {% endif %}
+        {% elif not article.erudit_object.abstracts %}
+        <p>
+          {{ article.erudit_object.html_body|safe|truncatewords_html:600 }}
+        </p>
+        {% endif %}
 
 
 				<!-- appendices -->

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -258,18 +258,6 @@
                 <span class="tools-label">{% trans "Partager" %}</span>
               </button>
             </li>
-            <li>
-              <button id="tool-print">
-                <span class="erudicon erudicon-tools-print"></span>
-                <span class="tools-label">{% trans "Imprimer" %}</span>
-              </button>
-            </li>
-            <li>
-              <button id="tool-fullscreen">
-                <span class="erudicon erudicon-tools-fullscreen"></span>
-                <span class="tools-label">{% trans "Mode zen" %}</span>
-              </button>
-            </li>
           </ul>
         </aside>
       </xsl:if>


### PR DESCRIPTION
Missing translations: 
- _Culturelle_ / _Savante_ (labels in `journal_list_per_names`)
- _Imprimer_ / _Mode zen_ (labels in toolbox of `eruditxsd300_to_html.xsl`)
- _Un [document type] de la revue_ (in `eruditxsd300_to_html.xsl` page header)