### PR TITLE
#1248 - Epigraphs, dedications, quotations, verbatims

### DIFF
--- a/eruditorg/static/js/controllers/public/journal/ArticleDetailController.js
+++ b/eruditorg/static/js/controllers/public/journal/ArticleDetailController.js
@@ -25,7 +25,7 @@ export default {
   sticky_elements : function () {
 
   	var $sticky_header 			  = this.article.find('.article-header-sticky'),
-  		  $sticky_elements 		  = this.article.find('.article-table-of-contents, .toolbox'),
+  		  $sticky_elements 		  = this.article.find('.article-table-of-contents, .toolbox, .pagination-arrow'),
   		  transform 				    = getPrefix('transform');
 
     // save sticky header height
@@ -35,7 +35,7 @@ export default {
     // sticky elements
   	$sticky_elements
       .css('padding-bottom', this.sticky_header_height)
-  		.stick_in_parent()
+  		.stick_in_parent({offset_top: 20})
   		.first()
   		.on("sticky_kit:stick", (e) => {
   			setTimeout(function(){

--- a/eruditorg/static/sass/PublicApp.scss
+++ b/eruditorg/static/sass/PublicApp.scss
@@ -61,6 +61,7 @@ $ionicons-font-path: '~ionicons/fonts';
   'components/navbars',
   'components/page-headers',
   'components/pagination',
+  'components/pagination-arrows',
   'components/panels',
   'components/scroll-top',
   'components/tables',

--- a/eruditorg/static/sass/base/_base.scss
+++ b/eruditorg/static/sass/base/_base.scss
@@ -49,6 +49,13 @@ textarea {
   line-height: inherit;
 }
 
+cite,
+var,
+address,
+dfn {
+  font-style: normal;
+}
+
 
 /** We reset this here because previously Normalize had no `figure` margins.
  * This ensures we don't break anyone's use of the element.

--- a/eruditorg/static/sass/components/_pagination-arrows.scss
+++ b/eruditorg/static/sass/components/_pagination-arrows.scss
@@ -26,9 +26,6 @@
     left: 5px;
   }
 
-  &.is_stuck {
-  }
-
   &:hover, &:active, &:active:focus {
     color: $white;
     background-color: $coral-red;

--- a/eruditorg/static/sass/components/_pagination-arrows.scss
+++ b/eruditorg/static/sass/components/_pagination-arrows.scss
@@ -1,0 +1,37 @@
+/**
+ * Pagination arrows for previous / next articles
+ */
+
+#article_detail .pagination-arrow {
+  position: absolute;
+  font-size: 40px;
+  color: $dark-grey;
+  transform: translate(0, -50%);
+  @include border-radius(50%);
+  width: 40px;
+  height: 40px;
+  line-height: 40px;
+  text-align: center;
+  margin-top: 30vh;
+
+  [data-hint] {
+    width: 100%;
+  }
+
+  &.next-page {
+    right: 5px;
+  }
+
+  &.previous-page {
+    left: 5px;
+  }
+
+  &.is_stuck {
+  }
+
+  &:hover, &:active, &:active:focus {
+    color: $white;
+    background-color: $coral-red;
+  }
+
+}

--- a/eruditorg/static/sass/components/_toolboxes.scss
+++ b/eruditorg/static/sass/components/_toolboxes.scss
@@ -3,7 +3,6 @@
  */
 .toolbox {
   position: relative;
-  padding-top: $margin-vertical-default;
   margin-right: $grid-gutter-width / 2;
   width: 50px;
   z-index: 10;

--- a/eruditorg/static/sass/components/_tooltips.scss
+++ b/eruditorg/static/sass/components/_tooltips.scss
@@ -12,6 +12,7 @@
   line-height: 1.35;
   font-size: 12px;
   @include font-styles('sans');
+  @include force-break;
 }
 
 .ion-alert {

--- a/eruditorg/static/sass/components/_tooltips.scss
+++ b/eruditorg/static/sass/components/_tooltips.scss
@@ -5,10 +5,13 @@
 
 [class*="hint--"]:after {
   width: 200px;
+  background: $darker-grey;
   white-space: normal;
+  font-variant: normal;
+  text-align: left;
   line-height: 1.35;
-  @include fw-sans;
   font-size: 12px;
+  @include font-styles('sans');
 }
 
 .ion-alert {

--- a/eruditorg/static/sass/components/article/_bibliographies.scss
+++ b/eruditorg/static/sass/components/article/_bibliographies.scss
@@ -11,12 +11,7 @@
 
    .refbiblio {
      margin-bottom: 0.5em;
-     // force breaks for long text, e.g. URLs
-     overflow-wrap: break-word;
-     word-wrap: break-word;
-     -ms-word-break: break-all;
-     word-break: break-all;
-     word-break: break-word;
+     @include force-break;
 
      a {
        font-size: 12px;

--- a/eruditorg/static/sass/components/article/_blockquotes.scss
+++ b/eruditorg/static/sass/components/article/_blockquotes.scss
@@ -1,0 +1,92 @@
+/**
+ * All quotation / blockquote types
+ * Includes <bloccitation>, <dedicace>, <epigraphe> and <verbatim>
+ */
+
+blockquote {
+
+  .source {
+    display: block;
+    color: $dark-grey;
+    font-size: smaller;
+    text-align: right;
+  }
+
+  .bloc {
+
+    &.gauche {
+      text-align: left;
+    }
+
+    &.centre {
+      text-align: center;
+    }
+
+    &.droite {
+      text-align: right;
+    }
+
+  }
+
+  &.bloccitation,
+  &.dedicace,
+  &.epigraphe,
+  &.verbatim {
+
+    p, li {
+      font-size: 14px;
+    }
+
+  }
+
+  &.dedicace,
+  &.epigraphe {
+    margin: 1.5em 0 2em 40%;
+    padding: 0;
+    border: 0;
+  }
+
+  &.dedicace {
+    text-align: right;
+    @include fw-serif-italic;
+  }
+
+  .verbatim,
+  &.verbatim {
+    border: 0;
+    padding: 0;
+    margin: 1.5em 0 1.5em 2.5em;
+
+    p,
+    .source,
+    + .source {
+      @include font-styles('sans');
+    }
+
+    // monospaced verbatims
+    &.formeef p,
+    &.poemeef p,
+    &.programme p {
+      @include font-styles('mono');
+    }
+
+    &.dialogue {}
+
+    &.forme {}
+
+    &.motpourmot {}
+
+    &.poeme {}
+
+  }
+
+  &.bloccitation {
+
+    .verbatim {
+      margin: 0;
+      padding: 0;
+    }
+
+  }
+
+}

--- a/eruditorg/static/sass/components/article/_formulae.scss
+++ b/eruditorg/static/sass/components/article/_formulae.scss
@@ -3,22 +3,21 @@
  */
 
  .equation {
-   padding-bottom: 1em;
-   margin-bottom: 1em;
-   border-bottom: 1px dotted $mid-grey;
+   padding: 0.75em 0;
 
-   &:first-of-type {
-     margin-top: 1.25em;
-   }
-
-   &:last-child {
+   &:first-child {
      padding-bottom: 0;
      margin-bottom: 0;
      border: 0;
    }
 
+   + .equation {
+     border-top: 1px dotted $mid-grey;
+   }
+
    p,
    .no {
+    margin: 0;
     font-size: 14px;
     @include font-styles(mono);
   }

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -443,6 +443,7 @@ $article-toolbar-width: 80px;
     // Import article body components
     @import
       '../../components/article/abstracts',
+      '../../components/article/blockquotes',
       '../../components/article/figures',
       '../../components/article/formulae',
       '../../components/article/lists',
@@ -504,7 +505,7 @@ $article-toolbar-width: 80px;
 
     }
 
-    p {
+    p, li, blockquote {
       @include paragraph-text-style;
     }
 
@@ -579,12 +580,6 @@ $article-toolbar-width: 80px;
       font-size: 1.25em;
     }
 
-  }
-
-  .source {
-    color: $dark-grey;
-    font-size: smaller;
-    text-align: right;
   }
 
   /**

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -24,7 +24,7 @@ $article-toolbar-width: 80px;
 * Styles for article detail
 */
 
-#article_detail {
+#article_detail main {
 
   /**
   * default for html elements
@@ -242,35 +242,6 @@ $article-toolbar-width: 80px;
 
     }
 
-    .pagination-arrow {
-      position: absolute;
-      top: 50%;
-      font-size: 40px;
-      color: $dark-grey;
-      transform: translate(0, -50%);
-      @include border-radius(50%);
-      width: 50px;
-      height: 50px;
-      line-height: 58px;
-      text-align: center;
-
-      &.next-page {
-        left: 100%;
-        margin-left: $grid-gutter-width/2;
-        padding-left: 4px;
-      }
-      &.previous-page {
-        right: 100%;
-        padding-right: 4px;
-        margin-right: $grid-gutter-width/2;
-      }
-
-      &:hover, &:active, &:active:focus {
-        color: $white;
-        background-color: $coral-red;
-      }
-    }
-
     .notegen,
     .histpapier,
     .erratum {
@@ -378,7 +349,6 @@ $article-toolbar-width: 80px;
   */
 
   .article-table-of-contents {
-    padding-top: $margin-vertical-default;
     position: relative;
     will-change: transform;
     @include transition(transform 0.3s ease-out);

--- a/eruditorg/static/sass/utils/_mixins.scss
+++ b/eruditorg/static/sass/utils/_mixins.scss
@@ -167,6 +167,15 @@
   column-count: $count;
 }
 
+// force breaks for long text, e.g. URLs
+@mixin force-break() {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+}
+
 /// Event wrapper
 /// @author Harry Roberts
 /// @param {Bool} $self [false] - Whether or not to include current selector
@@ -188,18 +197,7 @@
   }
 }
 
-/// Make a context based selector a little more friendly
-/// @author Hugo Giraudel
-/// @param {String} $context
-@mixin when-inside($context) {
-  #{$context} & {
-    @content;
-  }
-}
-
-/**
-* Create a top or bottom border for Bootstrap's grid cell
-*/
+// Create a top or bottom border for Bootstrap's grid cell
 @mixin grid-cell-border($direction: 'top', $border-width: 1px, $border-color: #000) {
   position: relative;
 
@@ -228,6 +226,15 @@
       bottom: 0;
       // clear: both;
     }
+  }
+}
+
+/// Make a context based selector a little more friendly
+/// @author Hugo Giraudel
+/// @param {String} $context
+@mixin when-inside($context) {
+  #{$context} & {
+    @content;
   }
 }
 

--- a/eruditorg/templates/public/journal/article_detail.html
+++ b/eruditorg/templates/public/journal/article_detail.html
@@ -115,6 +115,7 @@
 {% endblock structured_data %}
 
 {% block body_class %}public static-header{% endblock body_class %}
+{% block body_id %}article_detail{% endblock body_id %}
 {% block data_controller %}public:journal:article_detail{% endblock data_controller %}
 
 {% block header_class %}static{% endblock header_class %}
@@ -139,12 +140,42 @@
 
 {% block content %}
 <main
-    id="article_detail"
     class="container"
     data-document-id="{{ article.id }}"
     {% if article.id in request.saved_citations %}data-is-in-citation-list="true"{% else %}data-is-in-citation-list="false"{% endif %}
     role="main"
   >
+  {% if not only_summary %}
+  {% if previous_article %}
+  <a href="{% url 'public:journal:article_detail' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page">
+    <span class="hint--bottom-right hint--no-animate" data-hint="{{ previous_article.title }}">
+      <span class="ion ion-ios-arrow-left"></span>
+    </span>
+  </a>
+  {% endif %}
+  {% if next_article %}
+  <a href="{% url 'public:journal:article_detail' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page">
+    <span class="hint--bottom-left hint--no-animate" data-hint="{{ next_article.title }}">
+      <span class="ion ion-ios-arrow-right"></span>
+    </span>
+  </a>
+  {% endif %}
+  {% else %}
+  {% if previous_article %}
+  <a href="{% url 'public:journal:article_summary' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page">
+    <span class="hint--bottom-right hint--no-animate" data-hint="{{ previous_article.title }}">
+      <span class="ion ion-ios-arrow-left"></span>
+    </span>
+  </a>
+  {% endif %}
+  {% if next_article %}
+  <a href="{% url 'public:journal:article_summary' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page">
+    <span class="hint--bottom-left hint--no-animate" data-hint="{{ next_article.title }}">
+      <span class="ion ion-ios-arrow-right"></span>
+    </span>
+  </a>
+  {% endif %}
+  {% endif %}
 
   {% cache FOREVER_TTL "public_article_detail_content" article.id article_access_granted in_citation_list LANGUAGE_CODE %}
   {% if article.publication_allowed_by_authors %}
@@ -175,7 +206,7 @@
           <h4>{{ related_article.title }}</h4>
           {% if related_article.authors.all|length > 0 %}
           <footer class="meta">
-            <h5>Par {{ related_article.authors.all|join:", " }}</h5>
+            <h5>{% trans 'Par' %} {{ related_article.authors.all|join:", " }}</h5>
           </footer>
           {% endif %}
         </a>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -83,15 +83,6 @@
         <!-- TODO: cover image -->
         <div class="issue-cover col-sm-3">
         </div>
-
-        {% if not only_summary %}
-        {% if next_article %}<a href="{% url 'public:journal:article_detail' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page"><span class="ion ion-ios-arrow-right"></span></a>{% endif %}
-        {% if previous_article %}<a href="{% url 'public:journal:article_detail' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page"><span class="ion ion-ios-arrow-left"></span></a>{% endif %}
-        {% else %}
-        {% if next_article %}<a href="{% url 'public:journal:article_summary' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page"><span class="ion ion-ios-arrow-right"></span></a>{% endif %}
-        {% if previous_article %}<a href="{% url 'public:journal:article_summary' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page"><span class="ion ion-ios-arrow-left"></span></a>{% endif %}
-        {% endif %}
-
       </hgroup>
 
       <!-- article metadata -->

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -907,24 +907,28 @@
     </li>
   </xsl:template>
 
-  <!-- blockquotes, dedications, epigraphs -->
-  <xsl:template match="bloccitation">
-    <blockquote class="{name()}">
+  <!-- blockquotes, dedications, epigraphs, verbatims -->
+  <xsl:template match="bloccitation | dedicace | epigraphe | verbatim">
+    <blockquote class="{name()} {@typeverb}">
       <xsl:apply-templates/>
     </blockquote>
   </xsl:template>
 
-  <!-- verbatims -->
-  <xsl:template match="verbatim">
-    <div class="verbatim {@typeverb}">
+  <xsl:template match="bloccitation/source | dedicace/source | epigraphe/source | verbatim/source">
+    <cite class="source">
       <xsl:apply-templates/>
-    </div>
+    </cite>
   </xsl:template>
 
   <xsl:template match="bloc">
-    <div class="bloc">
+    <p class="bloc {@alignh}">
       <xsl:apply-templates/>
-    </div>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="bloc/ligne">
+    <xsl:apply-templates/>
+    <br/>
   </xsl:template>
 
   <!-- figures & tables -->
@@ -1974,11 +1978,11 @@
 
   <!--*** all-purpose typographic markup ***-->
   <xsl:template match="espacev">
-    <div class="espacev" style="height: {@dim}">&#x00A0;</div>
+    <span class="espacev {@espacetype}" style="height: {@dim}; display: block;">&#x00A0;</span>
   </xsl:template>
 
   <xsl:template match="espaceh">
-    <span class="espaceh" style="padding-left: {@dim}">&#x00A0;</span>
+    <span class="espaceh {@espacetype}" style="padding-left: {@dim};">&#x00A0;</span>
   </xsl:template>
 
   <xsl:template match="marquage">

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1,72 +1,72 @@
 {% load i18n %}{% load staticfiles %}<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:v="variables-node" version="2.0">
-	<xsl:output method="html" indent="yes" encoding="UTF-8"/>
-	<xsl:strip-space elements="*"/>
+  <xsl:output method="html" indent="yes" encoding="UTF-8"/>
+  <xsl:strip-space elements="*"/>
 
-	<!--=========== VARIABLES & PARAMETERS ===========-->
+  <!--=========== VARIABLES & PARAMETERS ===========-->
   <!-- possible values for cover - 'no', 'coverpage.jpg', 'no-image' -->
   <xsl:variable name="iderudit" select="article/@idproprio"/>
-	<xsl:variable name="typeudoc">
-		<xsl:choose>
-			<xsl:when test="article/@typeart='article'">
-				<xsl:value-of select="'article'" />
-			</xsl:when>
-			<xsl:when test="article/@typeart='compte rendu' or article/@typeart='compterendu'">
-				<xsl:value-of select="'compterendu'" />
-			</xsl:when>
-			<xsl:when test="starts-with(article/@typeart, 'note')">
-				<xsl:value-of select="'note'" />
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="'autre'" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:variable>
-	<xsl:variable name="titreAbrege" select="article/admin/revue/titrerevabr"/>
-	<xsl:variable name="uriStart">http://id.erudit.org/iderudit/</xsl:variable>
-	<xsl:variable name="doiStart">http://dx.doi.org/</xsl:variable>
+  <xsl:variable name="typeudoc">
+    <xsl:choose>
+      <xsl:when test="article/@typeart='article'">
+        <xsl:value-of select="'article'" />
+      </xsl:when>
+      <xsl:when test="article/@typeart='compte rendu' or article/@typeart='compterendu'">
+        <xsl:value-of select="'compterendu'" />
+      </xsl:when>
+      <xsl:when test="starts-with(article/@typeart, 'note')">
+        <xsl:value-of select="'note'" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'autre'" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:variable name="titreAbrege" select="article/admin/revue/titrerevabr"/>
+  <xsl:variable name="uriStart">http://id.erudit.org/iderudit/</xsl:variable>
+  <xsl:variable name="doiStart">http://dx.doi.org/</xsl:variable>
 
-	<v:variables>
-		{% for imid, infoimg in article.fedora_object.infoimg_dict.items %}
-		<v:variable n="src-{{ imid }}" value="{{ infoimg.src }}" />
-		<v:variable n="plgr-{{ imid }}" value="{{ infoimg.plgr }}" />
-		{% endfor %}
-	</v:variables>
-	<xsl:variable name="vars" select="document('')//v:variables/v:variable" />
+  <v:variables>
+    {% for imid, infoimg in article.fedora_object.infoimg_dict.items %}
+    <v:variable n="src-{{ imid }}" value="{{ infoimg.src }}" />
+    <v:variable n="plgr-{{ imid }}" value="{{ infoimg.plgr }}" />
+    {% endfor %}
+  </v:variables>
+  <xsl:variable name="vars" select="document('')//v:variables/v:variable" />
 
-	<!-- Savante, culturelle, ... -->
-	<xsl:param name="typecoll" />
+  <!-- Savante, culturelle, ... -->
+  <xsl:param name="typecoll" />
 
-	<!-- Eliminer les lignes vides dans le document resultant -->
-	<xsl:strip-space elements="alinea"/>
+  <!-- Eliminer les lignes vides dans le document resultant -->
+  <xsl:strip-space elements="alinea"/>
 
-	<xsl:template match="/">
-		<div class="article-wrapper">
-			<xsl:apply-templates select="article"/>
-		</div>
-	</xsl:template>
+  <xsl:template match="/">
+    <div class="article-wrapper">
+      <xsl:apply-templates select="article"/>
+    </div>
+  </xsl:template>
 
-	<xsl:template match="article">
+  <xsl:template match="article">
 
-		<!-- main header -->
-		<header class="row page-header-main article-header" id="article-header">
+    <!-- main header -->
+    <header class="row page-header-main article-header" id="article-header">
 
-			<hgroup class="col-xs-12 child-column-fit">
+      <hgroup class="col-xs-12 child-column-fit">
 
-				<div class="col-sm-9">
+        <div class="col-sm-9">
           <xsl:if test="liminaire/grtitre/surtitre">
             <p class="title-tag">
               <xsl:apply-templates select="liminaire/grtitre/surtitre" mode="title"/>
               <xsl:apply-templates select="liminaire/grtitre/surtitreparal" mode="title"/>
             </p>
           </xsl:if>
-					<h1>
-						<xsl:apply-templates select="liminaire/grtitre/titre" mode="title"/>
+          <h1>
+            <xsl:apply-templates select="liminaire/grtitre/titre" mode="title"/>
             <xsl:apply-templates select="liminaire/grtitre/sstitre" mode="title"/>
-						<xsl:apply-templates select="liminaire/grtitre/titreparal" mode="title"/>
+            <xsl:apply-templates select="liminaire/grtitre/titreparal" mode="title"/>
             <xsl:apply-templates select="liminaire/grtitre/sstitreparal" mode="title"/>
-						<xsl:apply-templates select="liminaire/grtitre/trefbiblio" mode="title"/>
-					</h1>
+            <xsl:apply-templates select="liminaire/grtitre/trefbiblio" mode="title"/>
+          </h1>
 
           <xsl:if test="liminaire/grauteur">
             <ul class="grauteur">
@@ -74,63 +74,63 @@
             </ul>
           </xsl:if>
 
-		  {% if only_summary %}
-		  <a href="{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" class="btn btn-primary">{% trans "Lire le texte integral" %} <span class="ion ion-arrow-right-c"></span></a>
-		  {% endif %}
+          {% if only_summary %}
+          <a href="{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" class="btn btn-primary">{% trans "Lire le texte integral" %} <span class="ion ion-arrow-right-c"></span></a>
+          {% endif %}
 
-				</div>
+        </div>
 
-				<!-- TODO: cover image -->
-				<div class="issue-cover col-sm-3">
-				</div>
+        <!-- TODO: cover image -->
+        <div class="issue-cover col-sm-3">
+        </div>
 
-				{% if not only_summary %}
-				{% if next_article %}<a href="{% url 'public:journal:article_detail' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page"><span class="ion ion-ios-arrow-right"></span></a>{% endif %}
-				{% if previous_article %}<a href="{% url 'public:journal:article_detail' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page"><span class="ion ion-ios-arrow-left"></span></a>{% endif %}
-				{% else %}
-				{% if next_article %}<a href="{% url 'public:journal:article_summary' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page"><span class="ion ion-ios-arrow-right"></span></a>{% endif %}
-				{% if previous_article %}<a href="{% url 'public:journal:article_summary' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page"><span class="ion ion-ios-arrow-left"></span></a>{% endif %}
-				{% endif %}
+        {% if not only_summary %}
+        {% if next_article %}<a href="{% url 'public:journal:article_detail' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page"><span class="ion ion-ios-arrow-right"></span></a>{% endif %}
+        {% if previous_article %}<a href="{% url 'public:journal:article_detail' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page"><span class="ion ion-ios-arrow-left"></span></a>{% endif %}
+        {% else %}
+        {% if next_article %}<a href="{% url 'public:journal:article_summary' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="pagination-arrow next-page"><span class="ion ion-ios-arrow-right"></span></a>{% endif %}
+        {% if previous_article %}<a href="{% url 'public:journal:article_summary' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="pagination-arrow previous-page"><span class="ion ion-ios-arrow-left"></span></a>{% endif %}
+        {% endif %}
 
-			</hgroup>
+      </hgroup>
 
-			<!-- article metadata -->
-			<div class="meta-article col-sm-6 border-top">
+      <!-- article metadata -->
+      <div class="meta-article col-sm-6 border-top">
 
         <xsl:apply-templates select="liminaire/erratum"/>
 
-				<dl class="mono-space idpublic">
-					<dt>URI</dt>
-					<dd>
+        <dl class="mono-space idpublic">
+          <dt>URI</dt>
+          <dd>
             <span class="hint--top hint--no-animate" data-hint="{% blocktrans %}Cliquez pour copier l'URI de cet article.{% endblocktrans %}">
-  						<a href="{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}" class="clipboard-data">
-  							{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}
-  							<span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
-  							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
-  						</a>
+              <a href="{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}" class="clipboard-data">
+                {{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:iderudit_article_detail' localid=article.localidentifier %}
+                <span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
+                <span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
+              </a>
             </span>
-					</dd>
+          </dd>
           {% if not article.issue.journal.type.code == 'C' %}
-					<dt>DOI</dt>
-					<dd>
+          <dt>DOI</dt>
+          <dd>
             <span class="hint--top hint--no-animate" data-hint="{% blocktrans %}Cliquez pour copier le DOI de cet article.{% endblocktrans %}">
-  						<a href="{$doiStart}10.7202/{$iderudit}" class="clipboard-data">
-  							10.7202/<xsl:value-of select="$iderudit"/>
-  							<span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
-  							<span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
-  						</a>
+              <a href="{$doiStart}10.7202/{$iderudit}" class="clipboard-data">
+                10.7202/<xsl:value-of select="$iderudit"/>
+                <span class="clipboard-msg clipboard-success">{% trans "adresse copiée" %}</span>
+                <span class="clipboard-msg clipboard-error">{% trans "une erreur s'est produite" %}</span>
+              </a>
             </span>
-					</dd>
+          </dd>
           {% endif %}
-				</dl>
+        </dl>
 
         <xsl:apply-templates select="liminaire/notegen"/>
         <xsl:apply-templates select="admin/histpapier"/>
 
-			</div>
+      </div>
 
-			<!-- journal metadata -->
-			<div class="meta-journal col-sm-6 border-top">
+      <!-- journal metadata -->
+      <div class="meta-journal col-sm-6 border-top">
         <p>
           {% blocktrans %}<xsl:apply-templates select="../article/@typeart"/> de la revue{% endblocktrans %}
           <a href="{{ request.is_secure|yesno:'https,http' }}://{{ request.site.domain }}{% url 'public:journal:journal_detail' article.issue.journal.code %}"><xsl:value-of select="admin/revue/titrerev"/></a>
@@ -143,9 +143,9 @@
           <xsl:apply-templates select="admin/numero/grtheme/theme" mode="refpapier"/>
         </p>
         <xsl:apply-templates select="admin/droitsauteur"/>
-			</div>
+      </div>
 
-		</header>
+    </header>
 
     <div id="article-content" class="row border-top">
       <xsl:if test="//corps">
@@ -274,13 +274,13 @@
         </div>
         {% endif %}
 
-				<!-- abstract -->
-				<xsl:if test="//resume">
-				<section id="resume" class="article-section grresume" role="complementary">
-          <h2 class="hidden">{% trans "Résumé" %}</h2>
-					<xsl:apply-templates select="//resume"/>
-				</section>
-				</xsl:if>
+        <!-- abstract -->
+        <xsl:if test="//resume">
+          <section id="resume" class="article-section grresume" role="complementary">
+            <h2 class="hidden">{% trans "Résumé" %}</h2>
+            <xsl:apply-templates select="//resume"/>
+          </section>
+        </xsl:if>
 
         {% if article_access_granted and not only_summary %}
         {% if article.erudit_object.processing == 'complet' %}
@@ -299,10 +299,10 @@
         {% endif %}
 
 
-				<!-- appendices -->
-				<xsl:apply-templates select="partiesann[node()]"/>
+        <!-- appendices -->
+        <xsl:apply-templates select="partiesann[node()]"/>
 
-				<!-- lists of tables & figures -->
+        <!-- lists of tables & figures -->
         <xsl:if test="//figure">
           <section id="figures" class="article-section figures" role="complementary">
             <h2>{% trans "Liste des figures" %}</h2>
@@ -317,12 +317,12 @@
           </section>
         </xsl:if>
 
-			</div>
-		</div>
+      </div>
+    </div>
 
-	</xsl:template>
+  </xsl:template>
 
-	<!--=========== TEMPLATES ===========-->
+  <!--=========== TEMPLATES ===========-->
 
   <!--**** HEADER ***-->
   <!-- identifiers -->
@@ -572,14 +572,14 @@
           <div class="motscles">
             <strong>Mots clés : </strong>
             <ul class="inline">
-            <xsl:for-each select="//grmotcle[@lang='fr']/motcle">
-              <li class="keyword">
-                <xsl:apply-templates/>
-                <xsl:if test="position() != last()">
-                  <xsl:text>, </xsl:text>
-                </xsl:if>
-              </li>
-            </xsl:for-each>
+              <xsl:for-each select="//grmotcle[@lang='fr']/motcle">
+                <li class="keyword">
+                  <xsl:apply-templates/>
+                  <xsl:if test="position() != last()">
+                    <xsl:text>, </xsl:text>
+                  </xsl:if>
+                </li>
+              </xsl:for-each>
             </ul>
           </div>
         </xsl:if>
@@ -603,14 +603,14 @@
           <div class="motscles">
             <strong>Keywords : </strong>
             <ul class="inline">
-            <xsl:for-each select="//grmotcle[@lang='en']/motcle">
-              <li class="keyword">
-                <xsl:apply-templates/>
-                <xsl:if test="position() != last()">
-                  <xsl:text>, </xsl:text>
-                </xsl:if>
-              </li>
-            </xsl:for-each>
+              <xsl:for-each select="//grmotcle[@lang='en']/motcle">
+                <li class="keyword">
+                  <xsl:apply-templates/>
+                  <xsl:if test="position() != last()">
+                    <xsl:text>, </xsl:text>
+                  </xsl:if>
+                </li>
+              </xsl:for-each>
             </ul>
           </div>
         </xsl:if>
@@ -634,14 +634,14 @@
           <div class="motscles">
             <strong>Palabras clave : </strong>
             <ul class="inline">
-            <xsl:for-each select="//grmotcle[@lang='es']/motcle">
-              <li class="keyword">
-                <xsl:apply-templates/>
-                <xsl:if test="position() != last()">
-                  <xsl:text>, </xsl:text>
-                </xsl:if>
-              </li>
-            </xsl:for-each>
+              <xsl:for-each select="//grmotcle[@lang='es']/motcle">
+                <li class="keyword">
+                  <xsl:apply-templates/>
+                  <xsl:if test="position() != last()">
+                    <xsl:text>, </xsl:text>
+                  </xsl:if>
+                </li>
+              </xsl:for-each>
             </ul>
           </div>
         </xsl:if>
@@ -734,12 +734,12 @@
       </xsl:choose>
     </xsl:if>
     <xsl:if test="self::grnotebio">
-        <xsl:choose>
-          <xsl:when test="titre">
-            <xsl:value-of select="titre"/>
-          </xsl:when>
-          <xsl:when test="count(notebio) = 1">{% trans "Note biographique" %}</xsl:when>
-          <xsl:otherwise>{% trans "Notes biographiques" %}</xsl:otherwise>
+      <xsl:choose>
+        <xsl:when test="titre">
+          <xsl:value-of select="titre"/>
+        </xsl:when>
+        <xsl:when test="count(notebio) = 1">{% trans "Note biographique" %}</xsl:when>
+        <xsl:otherwise>{% trans "Notes biographiques" %}</xsl:otherwise>
       </xsl:choose>
     </xsl:if>
     <xsl:if test="self::grnote">
@@ -752,12 +752,12 @@
       </xsl:choose>
     </xsl:if>
     <xsl:if test="self::merci">
-    <xsl:choose>
-      <xsl:when test="titre">
-        <xsl:value-of select="titre"/>
-      </xsl:when>
-      <xsl:otherwise>{% trans "Remerciements" %}</xsl:otherwise>
-    </xsl:choose>
+      <xsl:choose>
+        <xsl:when test="titre">
+          <xsl:value-of select="titre"/>
+        </xsl:when>
+        <xsl:otherwise>{% trans "Remerciements" %}</xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
     <xsl:if test="self::grbiblio">
       <xsl:choose>
@@ -767,183 +767,176 @@
     </xsl:if>
   </xsl:template>
 
-	<!--*** BODY ***-->
-	<xsl:template match="corps">
-			<xsl:apply-templates/>
-	</xsl:template>
+  <!--*** BODY ***-->
+  <xsl:template match="corps">
+    <xsl:apply-templates/>
+  </xsl:template>
 
-	<xsl:template match="section1">
-		<section id="{@id}">
-			<xsl:if test="titre">
-				<xsl:element name="h2">
-					<xsl:if test="titre/@traitementparticulier">
-						<xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates select="titre"/>
-				</xsl:element>
-			</xsl:if>
-			<xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
-		</section>
-	</xsl:template>
-	<xsl:template match="section2">
-		<section id="{@id}">
-			<xsl:if test="titre">
-				<xsl:element name="h3">
-					<xsl:if test="titre/@traitementparticulier">
-						<xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates select="titre"/>
-				</xsl:element>
-			</xsl:if>
-			<xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
-		</section>
-	</xsl:template>
-	<xsl:template match="section3">
-		<section id="{@id}">
-			<xsl:if test="titre">
-				<xsl:element name="h4">
-					<xsl:if test="titre/@traitementparticulier">
-						<xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates select="titre"/>
-				</xsl:element>
-			</xsl:if>
-			<xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
-		</section>
-	</xsl:template>
-	<xsl:template match="section4">
-		<section id="{@id}">
-			<xsl:if test="titre">
-				<xsl:element name="h5">
-					<xsl:if test="titre/@traitementparticulier">
-						<xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates select="titre"/>
-				</xsl:element>
-			</xsl:if>
-			<xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
-		</section>
-	</xsl:template>
-	<xsl:template match="section5">
-		<section id="{@id}">
-			<xsl:if test="titre">
-				<xsl:element name="h6">
-					<xsl:if test="titre/@traitementparticulier">
-						<xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates select="titre"/>
-				</xsl:element>
-			</xsl:if>
-			<xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
-		</section>
-	</xsl:template>
-	<xsl:template match="section6">
-		<section id="{@id}">
-			<xsl:if test="titre">
-				<xsl:element name="h6">
-					<xsl:attribute name="class">h7</xsl:attribute>
-					<xsl:if test="titre/@traitementparticulier">
-						<xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates select="titre"/>
-				</xsl:element>
-			</xsl:if>
-			<xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
-		</section>
-	</xsl:template>
-	<xsl:template match="para">
-		<div class="{name()}" id="{@id}">
-			<xsl:apply-templates select="no" mode="para"/>
-			<xsl:apply-templates select="*[not(self::no)]"/>
-		</div>
-	</xsl:template>
-	<xsl:template match="alinea">
-		<p class="{name()}">
-			<xsl:apply-templates/>
-		</p>
-	</xsl:template>
-	<xsl:template match="no" mode="para"></xsl:template>
-	<xsl:template match="section1/alinea|section2/alinea|section3/alinea|section4/alinea|section5/alinea|section6/alinea|grannexe/alinea"  priority="1">
-		<p class="horspara">
-			<xsl:apply-templates/>
-		</p>
-	</xsl:template>
-	<xsl:template match="no">
-		<xsl:apply-templates/>
-	</xsl:template>
-	<xsl:template match="no" mode="liste">
-		<span class="no">
-			<xsl:apply-templates select="*[not(self::renvoi)]"/>
-		</span>
-	</xsl:template>
-	<xsl:template match="legende/titre | legende/sstitre">
-		<p class="legende">
-  		<xsl:for-each select=".">
-  			<strong class="{name()}">
-  				<xsl:apply-templates/>
-  			</strong>
-  		</xsl:for-each>
+  <xsl:template match="section1">
+    <section id="{@id}">
+      <xsl:if test="titre">
+        <xsl:element name="h2">
+          <xsl:if test="titre/@traitementparticulier">
+            <xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates select="titre"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
+    </section>
+  </xsl:template>
+  <xsl:template match="section2">
+    <section id="{@id}">
+      <xsl:if test="titre">
+        <xsl:element name="h3">
+          <xsl:if test="titre/@traitementparticulier">
+            <xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates select="titre"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
+    </section>
+  </xsl:template>
+  <xsl:template match="section3">
+    <section id="{@id}">
+      <xsl:if test="titre">
+        <xsl:element name="h4">
+          <xsl:if test="titre/@traitementparticulier">
+            <xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates select="titre"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
+    </section>
+  </xsl:template>
+  <xsl:template match="section4">
+    <section id="{@id}">
+      <xsl:if test="titre">
+        <xsl:element name="h5">
+          <xsl:if test="titre/@traitementparticulier">
+            <xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates select="titre"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
+    </section>
+  </xsl:template>
+  <xsl:template match="section5">
+    <section id="{@id}">
+      <xsl:if test="titre">
+        <xsl:element name="h6">
+          <xsl:if test="titre/@traitementparticulier">
+            <xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates select="titre"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
+    </section>
+  </xsl:template>
+  <xsl:template match="section6">
+    <section id="{@id}">
+      <xsl:if test="titre">
+        <xsl:element name="h6">
+          <xsl:attribute name="class">h7</xsl:attribute>
+          <xsl:if test="titre/@traitementparticulier">
+            <xsl:attribute name="class">{% trans "special" %}</xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates select="titre"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)][not(self::titre)][not(self::titreparal)]"/>
+    </section>
+  </xsl:template>
+  <xsl:template match="para">
+    <div class="{name()}" id="{@id}">
+      <xsl:apply-templates select="no" mode="para"/>
+      <xsl:apply-templates select="*[not(self::no)]"/>
+    </div>
+  </xsl:template>
+  <xsl:template match="alinea">
+    <p class="{name()}">
+      <xsl:apply-templates/>
     </p>
-	</xsl:template>
-	<xsl:template match="legende/titre | legende/sstitre" mode="liste">
-		<div class="legende">
-		<xsl:for-each select=".">
-			<div class="{name()}">
-				<xsl:apply-templates select="*[not(self::renvoi)]"/>
-			</div>
-		</xsl:for-each>
-		</div>
-	</xsl:template>
-	<xsl:template match="ligne">
-		<xsl:apply-templates/>
-		<br/>
-	</xsl:template>
-	<xsl:template match="titre">
-			<xsl:apply-templates/>
-	</xsl:template>
-	<xsl:template match="elemliste">
-		<li>
-			<xsl:apply-templates/>
-		</li>
-	</xsl:template>
+  </xsl:template>
+  <xsl:template match="no" mode="para"></xsl:template>
+  <xsl:template match="section1/alinea|section2/alinea|section3/alinea|section4/alinea|section5/alinea|section6/alinea|grannexe/alinea"  priority="1">
+    <p class="horspara">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+  <xsl:template match="no">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="no" mode="liste">
+    <span class="no">
+      <xsl:apply-templates select="*[not(self::renvoi)]"/>
+    </span>
+  </xsl:template>
+  <xsl:template match="legende/titre | legende/sstitre">
+    <p class="legende">
+      <xsl:for-each select=".">
+        <strong class="{name()}">
+          <xsl:apply-templates/>
+        </strong>
+      </xsl:for-each>
+    </p>
+  </xsl:template>
+  <xsl:template match="legende/titre | legende/sstitre" mode="liste">
+    <div class="legende">
+      <xsl:for-each select=".">
+        <div class="{name()}">
+          <xsl:apply-templates select="*[not(self::renvoi)]"/>
+        </div>
+      </xsl:for-each>
+    </div>
+  </xsl:template>
+  <xsl:template match="ligne">
+    <xsl:apply-templates/>
+    <br/>
+  </xsl:template>
+  <xsl:template match="titre">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="elemliste">
+    <li>
+      <xsl:apply-templates/>
+    </li>
+  </xsl:template>
 
-  <!-- blockquotes -->
-	<xsl:template match="bloccitation">
-		<blockquote>
-			<xsl:apply-templates/>
-		</blockquote>
-	</xsl:template>
-
-  <!-- dedications, epigraphs -->
-	<xsl:template match="dedicace|epigraphe">
-		<div class="{name()}">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
+  <!-- blockquotes, dedications, epigraphs -->
+  <xsl:template match="bloccitation">
+    <blockquote class="{name()}">
+      <xsl:apply-templates/>
+    </blockquote>
+  </xsl:template>
 
   <!-- verbatims -->
-	<xsl:template match="verbatim">
-		<div class="verbatim {@typeverb}">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
+  <xsl:template match="verbatim">
+    <div class="verbatim {@typeverb}">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
 
-	<xsl:template match="bloc">
-		<div class="bloc">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
+  <xsl:template match="bloc">
+    <div class="bloc">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
 
   <!-- figures & tables -->
-	<xsl:template match="grfigure|grtableau">
-		<div class="{name()}" id="{@id}">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
+  <xsl:template match="grfigure|grtableau">
+    <div class="{name()}" id="{@id}">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
 
-	<xsl:template match="figure|tableau">
-		<xsl:apply-templates select="objetmedia"/>
-	</xsl:template>
+  <xsl:template match="figure|tableau">
+    <xsl:apply-templates select="objetmedia"/>
+  </xsl:template>
 
   <xsl:template match="figure/objetmedia|tableau/objetmedia">
     <xsl:variable name="imgSrcId" select="concat('src-', image/@id)"/>
@@ -968,801 +961,801 @@
   </xsl:template>
 
   <!-- equations, examples & insets/boxed text -->
-	<xsl:template match="grencadre|grequation|grexemple">
-		<aside class="{name()}">
-			<xsl:apply-templates select="no"/>
-			<xsl:apply-templates select="legende"/>
-			<xsl:apply-templates select="*[not(self::no)][not(self::legende)][not(self::titreparal)]"/>
-		</aside>
-	</xsl:template>
-	<xsl:template match="encadre">
-		<aside class="encadre type{@type}">
-			<xsl:apply-templates/>
-		</aside>
-	</xsl:template>
+  <xsl:template match="grencadre|grequation|grexemple">
+    <aside class="{name()}">
+      <xsl:apply-templates select="no"/>
+      <xsl:apply-templates select="legende"/>
+      <xsl:apply-templates select="*[not(self::no)][not(self::legende)][not(self::titreparal)]"/>
+    </aside>
+  </xsl:template>
+  <xsl:template match="encadre">
+    <aside class="encadre type{@type}">
+      <xsl:apply-templates/>
+    </aside>
+  </xsl:template>
 
   <!-- notes within equations, examples and insets -->
-	<xsl:template match="noteenc|noteeq|noteex">
-		<xsl:call-template name="noteillustrationtype">
-			<xsl:with-param name="noteIllustration" select="."/>
-		</xsl:call-template>
-	</xsl:template>
-	<xsl:template match="equation">
-		<xsl:variable name="valeurID" select="@id"/>
-		<aside class="equation">
-			<!-- Les numéros -->
-			<xsl:for-each select="no">
-				<span class="no">
-				<xsl:call-template name="syntaxe_texte_affichage">
-					<xsl:with-param name="texte" select="."/>
-				</xsl:call-template>
-				</span>
-			</xsl:for-each>
-			<!-- L'équation proprement dite -->
-			<xsl:for-each        select="node()[ name() = 'alinea' or name() = 'bloccitation' or name() = 'listenonord' or name() = 'listeord' or name() = 'listerelation' or        name() = 'objetmedia' or        name() = 'refbiblio' or        name() = 'verbatim']">
-				<xsl:apply-templates select="."/>
-			</xsl:for-each>
-			<!-- Les légendes -->
-			<xsl:if test="legende">
-				<div class="legende">
-				<xsl:for-each select="legende">
-					<xsl:apply-templates/>
-				</xsl:for-each>
-				</div>
-			</xsl:if>
-			<xsl:for-each select="node()[name() = 'noteeq' or name() = 'source']">
-				<xsl:apply-templates select="."/>
-			</xsl:for-each>
-		</aside>
-	</xsl:template>
-	<xsl:template match="exemple">
-		<aside class="exemple">
-			<xsl:apply-templates select="no"/>
-			<xsl:apply-templates select="legende"/>
-			<xsl:for-each select="node()[name() != '' and name() != 'no' and name() != 'legende']">
-				<xsl:apply-templates select="."/>
-			</xsl:for-each>
-		</aside>
-	</xsl:template>
+  <xsl:template match="noteenc|noteeq|noteex">
+    <xsl:call-template name="noteillustrationtype">
+      <xsl:with-param name="noteIllustration" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+  <xsl:template match="equation">
+    <xsl:variable name="valeurID" select="@id"/>
+    <aside class="equation">
+      <!-- Les numéros -->
+      <xsl:for-each select="no">
+        <span class="no">
+          <xsl:call-template name="syntaxe_texte_affichage">
+            <xsl:with-param name="texte" select="."/>
+          </xsl:call-template>
+        </span>
+      </xsl:for-each>
+      <!-- L'équation proprement dite -->
+      <xsl:for-each        select="node()[ name() = 'alinea' or name() = 'bloccitation' or name() = 'listenonord' or name() = 'listeord' or name() = 'listerelation' or        name() = 'objetmedia' or        name() = 'refbiblio' or        name() = 'verbatim']">
+        <xsl:apply-templates select="."/>
+      </xsl:for-each>
+      <!-- Les légendes -->
+      <xsl:if test="legende">
+        <div class="legende">
+          <xsl:for-each select="legende">
+            <xsl:apply-templates/>
+          </xsl:for-each>
+        </div>
+      </xsl:if>
+      <xsl:for-each select="node()[name() = 'noteeq' or name() = 'source']">
+        <xsl:apply-templates select="."/>
+      </xsl:for-each>
+    </aside>
+  </xsl:template>
+  <xsl:template match="exemple">
+    <aside class="exemple">
+      <xsl:apply-templates select="no"/>
+      <xsl:apply-templates select="legende"/>
+      <xsl:for-each select="node()[name() != '' and name() != 'no' and name() != 'legende']">
+        <xsl:apply-templates select="."/>
+      </xsl:for-each>
+    </aside>
+  </xsl:template>
 
   <!-- media objects -->
-	<xsl:template match="objetmedia/audio">
-		<xsl:variable name="nomAud" select="@*[local-name()='href']"/>
-		<audio id="{@id}" class="img-responsive" preload="metadata" controls="controls">
-			<source src="http://erudit.org/media/{$titreAbrege}/{$iderudit}/{$nomAud}" type="{@typemime}"/>
-		</audio>
-	</xsl:template>
-	<xsl:template match="objetmedia/image">
-		<xsl:variable name="nomImg" select="@*[local-name()='href']"/>
-		<span class="lien_img">
-			<img src="{{ request.get_full_path }}media/{$nomImg}" class="objetmedia_img"/>
-		</span>
-	</xsl:template>
-	<xsl:template match="objetmedia/texte">
-		<div class="objetTexte">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
-	<xsl:template match="objetmedia/video">
-		<xsl:variable name="videohref" select="@*[local-name()='href']"/>
-		<xsl:variable name="nomVid" select="substring-before($videohref, '.')"/>
-		<video id="{@id}" class="img-responsive" preload="metadata" controls="controls">
-			<source src="http://erudit.org/media/{$titreAbrege}/{$iderudit}/{$nomVid}.mp4" type="video/mp4"/>
-		</video>
-	</xsl:template>
+  <xsl:template match="objetmedia/audio">
+    <xsl:variable name="nomAud" select="@*[local-name()='href']"/>
+    <audio id="{@id}" class="img-responsive" preload="metadata" controls="controls">
+      <source src="http://erudit.org/media/{$titreAbrege}/{$iderudit}/{$nomAud}" type="{@typemime}"/>
+    </audio>
+  </xsl:template>
+  <xsl:template match="objetmedia/image">
+    <xsl:variable name="nomImg" select="@*[local-name()='href']"/>
+    <span class="lien_img">
+      <img src="{{ request.get_full_path }}media/{$nomImg}" class="objetmedia_img"/>
+    </span>
+  </xsl:template>
+  <xsl:template match="objetmedia/texte">
+    <div class="objetTexte">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+  <xsl:template match="objetmedia/video">
+    <xsl:variable name="videohref" select="@*[local-name()='href']"/>
+    <xsl:variable name="nomVid" select="substring-before($videohref, '.')"/>
+    <video id="{@id}" class="img-responsive" preload="metadata" controls="controls">
+      <source src="http://erudit.org/media/{$titreAbrege}/{$iderudit}/{$nomVid}.mp4" type="video/mp4"/>
+    </video>
+  </xsl:template>
 
   <!-- grobjet & objet -->
-	<xsl:template match="grobjet">
-		<xsl:apply-templates/>
-	</xsl:template>
-	<xsl:template match="objet">
-		<div class="objet">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
+  <xsl:template match="grobjet">
+    <xsl:apply-templates/>
+  </xsl:template>
+  <xsl:template match="objet">
+    <div class="objet">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
 
   <!-- lists -->
-	<xsl:template match="listenonord">
-		<xsl:variable name="signe" select="@signe"/>
-		<xsl:choose>
-			<xsl:when test="@nbcol">
-				<!-- listenonord multi-colonnes -->
-				<xsl:variable name="elemlistes" select="elemliste"/>
-				<xsl:variable name="nbElems" select="count($elemlistes)"/>
-				<xsl:variable name="nbCols" select="@nbcol"/>
-				<xsl:variable name="divClass" select="concat('nbcol', $nbCols)"/>
-				<xsl:variable name="quotient" select="floor($nbElems div $nbCols)"/>
-				<xsl:variable name="reste" select="$nbElems mod $nbCols"/>
-				<!-- maximum 5 colonnes -->
-				<div class="multicolonne">
-					<xsl:variable name="arret1" select="$quotient + number($reste &gt; 0)"/>
-					<div class="{$divClass}">
-						<ul class="{$signe}">
-							<xsl:for-each select="elemliste[position() &gt; 0 and position() &lt;= $arret1]">
-								<xsl:apply-templates select="."/>
-							</xsl:for-each>
-						</ul>
-					</div>
-					<xsl:if test="$nbCols &gt;= 2">
-						<xsl:variable name="arret2" select="$arret1 + $quotient + number($reste &gt; 1)"/>
-						<div class="{$divClass}">
-							<ul class="{$signe}">
-								<xsl:for-each select="elemliste[position() &gt; $arret1 and position() &lt;= $arret2]">
-									<xsl:apply-templates select="."/>
-								</xsl:for-each>
-							</ul>
-						</div>
-						<xsl:if test="$nbCols &gt;= 3">
-							<xsl:variable name="arret3" select="$arret2 + $quotient + number($reste &gt; 2)"/>
-							<div class="{$divClass}">
-								<ul class="{$signe}">
-									<xsl:for-each select="elemliste[position() &gt; $arret2 and position() &lt;= $arret3]">
-										<xsl:apply-templates select="."/>
-									</xsl:for-each>
-								</ul>
-							</div>
-							<xsl:if test="$nbCols &gt;= 4">
-								<xsl:variable name="arret4" select="$arret3 + $quotient + number($reste &gt; 3)"/>
-								<div class="{$divClass}">
-									<ul class="{$signe}">
-										<xsl:for-each select="elemliste[position() &gt; $arret3 and position() &lt;= $arret4]">
-											<xsl:apply-templates select="."/>
-										</xsl:for-each>
-									</ul>
-								</div>
-								<xsl:if test="$nbCols &gt;= 5">
-									<xsl:variable name="arret5" select="$arret4 + $quotient + number($reste &gt; 4)"/>
-									<div class="{$divClass}">
-										<ul class="{$signe}">
-											<xsl:for-each select="elemliste[position() &gt; $arret4 and position() &lt;= $arret5]">
-												<xsl:apply-templates select="."/>
-											</xsl:for-each>
-										</ul>
-									</div>
-								</xsl:if>
-							</xsl:if>
-						</xsl:if>
-					</xsl:if>
-				</div>
-			</xsl:when>
-			<xsl:otherwise>
-				<!-- listenonord 1 colonne -->
-				<ul class="{@signe}">
-					<xsl:apply-templates/>
-				</ul>
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+  <xsl:template match="listenonord">
+    <xsl:variable name="signe" select="@signe"/>
+    <xsl:choose>
+      <xsl:when test="@nbcol">
+        <!-- listenonord multi-colonnes -->
+        <xsl:variable name="elemlistes" select="elemliste"/>
+        <xsl:variable name="nbElems" select="count($elemlistes)"/>
+        <xsl:variable name="nbCols" select="@nbcol"/>
+        <xsl:variable name="divClass" select="concat('nbcol', $nbCols)"/>
+        <xsl:variable name="quotient" select="floor($nbElems div $nbCols)"/>
+        <xsl:variable name="reste" select="$nbElems mod $nbCols"/>
+        <!-- maximum 5 colonnes -->
+        <div class="multicolonne">
+          <xsl:variable name="arret1" select="$quotient + number($reste &gt; 0)"/>
+          <div class="{$divClass}">
+            <ul class="{$signe}">
+              <xsl:for-each select="elemliste[position() &gt; 0 and position() &lt;= $arret1]">
+                <xsl:apply-templates select="."/>
+              </xsl:for-each>
+            </ul>
+          </div>
+          <xsl:if test="$nbCols &gt;= 2">
+            <xsl:variable name="arret2" select="$arret1 + $quotient + number($reste &gt; 1)"/>
+            <div class="{$divClass}">
+              <ul class="{$signe}">
+                <xsl:for-each select="elemliste[position() &gt; $arret1 and position() &lt;= $arret2]">
+                  <xsl:apply-templates select="."/>
+                </xsl:for-each>
+              </ul>
+            </div>
+            <xsl:if test="$nbCols &gt;= 3">
+              <xsl:variable name="arret3" select="$arret2 + $quotient + number($reste &gt; 2)"/>
+              <div class="{$divClass}">
+                <ul class="{$signe}">
+                  <xsl:for-each select="elemliste[position() &gt; $arret2 and position() &lt;= $arret3]">
+                    <xsl:apply-templates select="."/>
+                  </xsl:for-each>
+                </ul>
+              </div>
+              <xsl:if test="$nbCols &gt;= 4">
+                <xsl:variable name="arret4" select="$arret3 + $quotient + number($reste &gt; 3)"/>
+                <div class="{$divClass}">
+                  <ul class="{$signe}">
+                    <xsl:for-each select="elemliste[position() &gt; $arret3 and position() &lt;= $arret4]">
+                      <xsl:apply-templates select="."/>
+                    </xsl:for-each>
+                  </ul>
+                </div>
+                <xsl:if test="$nbCols &gt;= 5">
+                  <xsl:variable name="arret5" select="$arret4 + $quotient + number($reste &gt; 4)"/>
+                  <div class="{$divClass}">
+                    <ul class="{$signe}">
+                      <xsl:for-each select="elemliste[position() &gt; $arret4 and position() &lt;= $arret5]">
+                        <xsl:apply-templates select="."/>
+                      </xsl:for-each>
+                    </ul>
+                  </div>
+                </xsl:if>
+              </xsl:if>
+            </xsl:if>
+          </xsl:if>
+        </div>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- listenonord 1 colonne -->
+        <ul class="{@signe}">
+          <xsl:apply-templates/>
+        </ul>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
-	<xsl:template match="listeord">
-		<xsl:variable name="numeration" select="@numeration"/>
-		<xsl:variable name="start">
-			<xsl:choose>
-				<xsl:when test="@compteur">
-					<xsl:value-of select="@compteur"/>
-				</xsl:when>
-				<xsl:otherwise>1</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="@nbcol">
-				<!-- listeord multi-colonnes -->
-				<xsl:variable name="elemlistes" select="elemliste"/>
-				<xsl:variable name="nbElems" select="count($elemlistes)"/>
-				<xsl:variable name="nbCols" select="@nbcol"/>
-				<xsl:variable name="divClass" select="concat('nbcol', $nbCols)"/>
-				<xsl:variable name="quotient" select="floor($nbElems div $nbCols)"/>
-				<xsl:variable name="reste" select="$nbElems mod $nbCols"/>
-				<!-- maximum 5 colonnes -->
-				<div class="multicolonne">
-					<xsl:variable name="arret1" select="$quotient + number($reste &gt; 0)"/>
-					<div class="{$divClass}">
-						<ol class="{$numeration}" start="{$start}">
-							<xsl:for-each select="elemliste[position() &gt; 0 and position() &lt;= $arret1]">
-								<xsl:apply-templates select="."/>
-							</xsl:for-each>
-						</ol>
-					</div>
-					<xsl:if test="$nbCols &gt;= 2">
-						<xsl:variable name="arret2" select="$arret1 + $quotient + number($reste &gt; 1)"/>
-						<div class="{$divClass}">
-							<ol class="{$numeration}" start="{$start + $arret1}">
-								<xsl:for-each select="elemliste[position() &gt; $arret1 and position() &lt;= $arret2]">
-									<xsl:apply-templates select="."/>
-								</xsl:for-each>
-							</ol>
-						</div>
-						<xsl:if test="$nbCols &gt;= 3">
-							<xsl:variable name="arret3" select="$arret2 + $quotient + number($reste &gt; 2)"/>
-							<div class="{$divClass}">
-								<ol class="$numeration" start="{$start + $arret2}">
-									<xsl:for-each select="elemliste[position() &gt; $arret2 and position() &lt;= $arret3]">
-										<xsl:apply-templates select="."/>
-									</xsl:for-each>
-								</ol>
-							</div>
-							<xsl:if test="$nbCols &gt;= 4">
-								<xsl:variable name="arret4" select="$arret3 + $quotient + number($reste &gt; 3)"/>
-								<div class="{$divClass}">
-									<ol class="$numeration" start="{$start + $arret3}">
-										<xsl:for-each select="elemliste[position() &gt; $arret3 and position() &lt;= $arret4]">
-											<xsl:apply-templates select="."/>
-										</xsl:for-each>
-									</ol>
-								</div>
-								<xsl:if test="$nbCols &gt;= 5">
-									<xsl:variable name="arret5" select="$arret4 + $quotient + number($reste &gt; 4)"/>
-									<div class="{$divClass}">
-										<ol class="$numeration" start="{$start + $arret4}">
-											<xsl:for-each select="elemliste[position() &gt; $arret4 and position() &lt;= $arret5]">
-												<xsl:apply-templates select="."/>
-											</xsl:for-each>
-										</ol>
-									</div>
-								</xsl:if>
-							</xsl:if>
-						</xsl:if>
-					</xsl:if>
-				</div>
-			</xsl:when>
-			<xsl:otherwise>
-				<!-- listeord 1 colonne -->
-				<xsl:element name="ol">
-					<xsl:attribute name="class">
-						<xsl:value-of select="@numeration"/>
-					</xsl:attribute>
-					<xsl:if test="@compteur">
-						<xsl:attribute name="start">
-							<xsl:value-of select="$start"/>
-						</xsl:attribute>
-					</xsl:if>
-					<xsl:apply-templates/>
-				</xsl:element>
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+  <xsl:template match="listeord">
+    <xsl:variable name="numeration" select="@numeration"/>
+    <xsl:variable name="start">
+      <xsl:choose>
+        <xsl:when test="@compteur">
+          <xsl:value-of select="@compteur"/>
+        </xsl:when>
+        <xsl:otherwise>1</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="@nbcol">
+        <!-- listeord multi-colonnes -->
+        <xsl:variable name="elemlistes" select="elemliste"/>
+        <xsl:variable name="nbElems" select="count($elemlistes)"/>
+        <xsl:variable name="nbCols" select="@nbcol"/>
+        <xsl:variable name="divClass" select="concat('nbcol', $nbCols)"/>
+        <xsl:variable name="quotient" select="floor($nbElems div $nbCols)"/>
+        <xsl:variable name="reste" select="$nbElems mod $nbCols"/>
+        <!-- maximum 5 colonnes -->
+        <div class="multicolonne">
+          <xsl:variable name="arret1" select="$quotient + number($reste &gt; 0)"/>
+          <div class="{$divClass}">
+            <ol class="{$numeration}" start="{$start}">
+              <xsl:for-each select="elemliste[position() &gt; 0 and position() &lt;= $arret1]">
+                <xsl:apply-templates select="."/>
+              </xsl:for-each>
+            </ol>
+          </div>
+          <xsl:if test="$nbCols &gt;= 2">
+            <xsl:variable name="arret2" select="$arret1 + $quotient + number($reste &gt; 1)"/>
+            <div class="{$divClass}">
+              <ol class="{$numeration}" start="{$start + $arret1}">
+                <xsl:for-each select="elemliste[position() &gt; $arret1 and position() &lt;= $arret2]">
+                  <xsl:apply-templates select="."/>
+                </xsl:for-each>
+              </ol>
+            </div>
+            <xsl:if test="$nbCols &gt;= 3">
+              <xsl:variable name="arret3" select="$arret2 + $quotient + number($reste &gt; 2)"/>
+              <div class="{$divClass}">
+                <ol class="$numeration" start="{$start + $arret2}">
+                  <xsl:for-each select="elemliste[position() &gt; $arret2 and position() &lt;= $arret3]">
+                    <xsl:apply-templates select="."/>
+                  </xsl:for-each>
+                </ol>
+              </div>
+              <xsl:if test="$nbCols &gt;= 4">
+                <xsl:variable name="arret4" select="$arret3 + $quotient + number($reste &gt; 3)"/>
+                <div class="{$divClass}">
+                  <ol class="$numeration" start="{$start + $arret3}">
+                    <xsl:for-each select="elemliste[position() &gt; $arret3 and position() &lt;= $arret4]">
+                      <xsl:apply-templates select="."/>
+                    </xsl:for-each>
+                  </ol>
+                </div>
+                <xsl:if test="$nbCols &gt;= 5">
+                  <xsl:variable name="arret5" select="$arret4 + $quotient + number($reste &gt; 4)"/>
+                  <div class="{$divClass}">
+                    <ol class="$numeration" start="{$start + $arret4}">
+                      <xsl:for-each select="elemliste[position() &gt; $arret4 and position() &lt;= $arret5]">
+                        <xsl:apply-templates select="."/>
+                      </xsl:for-each>
+                    </ol>
+                  </div>
+                </xsl:if>
+              </xsl:if>
+            </xsl:if>
+          </xsl:if>
+        </div>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- listeord 1 colonne -->
+        <xsl:element name="ol">
+          <xsl:attribute name="class">
+            <xsl:value-of select="@numeration"/>
+          </xsl:attribute>
+          <xsl:if test="@compteur">
+            <xsl:attribute name="start">
+              <xsl:value-of select="$start"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates/>
+        </xsl:element>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
-	<xsl:template match="listerelation">
-	  <!-- Syntaxe (#PCDATA | %texte;)* mode affichage -->
-	  <xsl:variable name="type" select="@type"/>
-	  <xsl:variable name="numeration" select="@numeration"/>
-	  <xsl:variable name="tableClass" select="concat( 'listerelation type', $type )"/>
-	  <xsl:variable name="nos" select="no"/>
-	  <xsl:variable name="lrsources" select="lrsource"/>
-	  <xsl:variable name="lrcibles" select="lrcible"/>
-	  <xsl:variable name="symbole" select="@symbole"/>
-	  <xsl:choose>
-	      <xsl:when test="@nbcol">
-	          <!-- listerelation colonnes multiples (2) -->
-	          <xsl:variable name="nbCols" select="@nbcol"/>
-	          <xsl:variable name="divClass" select="concat('nbcol', $nbCols)"/>
-	          <xsl:variable name="nbElems" select="count($lrsources)"/>
-	          <xsl:variable name="quotient" select="floor($nbElems div $nbCols)"/>
-	          <xsl:variable name="reste" select="$nbElems mod $nbCols"/>
-	          <xsl:variable name="arret1" select="$quotient + number( $reste &gt; 0 )"/>
-	          <div class="multicolonne">
-	              <xsl:choose>
-	                  <xsl:when test="$type &lt; 4">
-	                      <div class="{$divClass}">
-	                          <table class="{$tableClass}">
-	                              <xsl:for-each select="$lrsources[ position() &lt;= $arret1]">
-	                                  <xsl:variable name="seq" select="position()"/>
-	                                  <tr>
-	                                      <xsl:if test="$nos">
-	                                          <td class="lrno">
-	                                              <p>
-	                                                  <xsl:call-template name="syntaxe_texte_affichage">
-	                                                      <xsl:with-param name="texte" select="$nos[$seq]"/>
-	                                                  </xsl:call-template>
-	                                              </p>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <td class="lrsource">
-	                                          <xsl:apply-templates/>
-	                                      </td>
-	                                      <xsl:if test="$symbole != ''">
-	                                          <td class="centre_symbole">
-	                                              <span>
-	                                                  <xsl:value-of select="$symbole"/>
-	                                              </span>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <td class="lrcible">
-	                                          <xsl:apply-templates select="$lrcibles[$seq]"/>
-	                                      </td>
-	                                  </tr>
-	                              </xsl:for-each>
-	                          </table>
-	                      </div>
-	                      <xsl:if test="$arret1 &lt; $nbElems">
-	                          <div class="$divClass">
-	                              <table class="{$tableClass}">
-	                                  <xsl:for-each select="$lrsources[ (position() &gt; $arret1) and (position() &lt;= $nbElems) ]">
-	                                      <xsl:variable name="seq" select="position()"/>
-	                                      <tr>
-	                                          <xsl:if test="$nos">
-	                                              <td class="lrno">
-	                                                  <p>
-	                                                      <xsl:call-template name="syntaxe_texte_affichage">
-	                                                          <xsl:with-param name="texte" select="$nos[$arret1 + $seq]"/>
-	                                                      </xsl:call-template>
-	                                                  </p>
-	                                              </td>
-	                                          </xsl:if>
-	                                          <td class="lrsource">
-	                                              <xsl:apply-templates/>
-	                                          </td>
-	                                          <xsl:if test="$symbole != ''">
-	                                              <td class="centre_symbole">
-	                                                  <span>
-	                                                      <xsl:value-of select="$symbole"/>
-	                                                  </span>
-	                                              </td>
-	                                          </xsl:if>
-	                                          <td class="lrcible">
-	                                              <xsl:apply-templates select="$lrcibles[$arret1 + $seq]"/>
-	                                          </td>
-	                                      </tr>
-	                                  </xsl:for-each>
-	                              </table>
-	                          </div>
-	                      </xsl:if>
-	                  </xsl:when>
-	                  <xsl:otherwise>
-	                      <div class="{$divClass}">
-	                          <table class="{$tableClass}">
-	                              <xsl:for-each select="$lrsources[ position() &lt;= $arret1]">
-	                                  <xsl:variable name="seq" select="position()"/>
-	                                  <tr>
-	                                      <xsl:if test="$nos">
-	                                          <td class="lrno" rowspan="2">
-	                                              <p>
-	                                                  <xsl:call-template name="syntaxe_texte_affichage">
-	                                                      <xsl:with-param name="texte" select="$nos[$seq]"/>
-	                                                  </xsl:call-template>
-	                                              </p>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <td class="lrsource">
-	                                          <xsl:apply-templates/>
-	                                      </td>
-	                                  </tr>
-	                                  <tr>
-	                                      <td class="lrcible">
-	                                          <xsl:apply-templates select="$lrcibles[$seq]"/>
-	                                      </td>
-	                                  </tr>
-	                              </xsl:for-each>
-	                          </table>
-	                      </div>
-	                      <xsl:if test="$arret1 &lt; $nbElems">
-	                          <div class="{$divClass}">
-	                              <table class="{$tableClass}">
-	                                  <xsl:for-each select="$lrsources[ (position() &gt; $arret1) and (position() &lt;= $nbElems) ]">
-	                                      <xsl:variable name="seq" select="position()"/>
-	                                      <tr>
-	                                          <xsl:if test="$nos">
-	                                              <td class="lrno" rowspan="2">
-	                                                  <p>
-	                                                      <xsl:call-template name="syntaxe_texte_affichage">
-	                                                          <xsl:with-param name="texte" select="$nos[$arret1 + $seq]"/>
-	                                                      </xsl:call-template>
-	                                                  </p>
-	                                              </td>
-	                                          </xsl:if>
-	                                          <td class="lrsource">
-	                                              <xsl:apply-templates/>
-	                                          </td>
-	                                      </tr>
-	                                      <tr>
-	                                          <td class="lrcible">
-	                                              <xsl:apply-templates select="$lrcibles[$arret1 + $seq]"/>
-	                                          </td>
-	                                      </tr>
-	                                  </xsl:for-each>
-	                              </table>
-	                          </div>
-	                      </xsl:if>
-	                  </xsl:otherwise>
-	              </xsl:choose>
-	          </div>
-	      </xsl:when>
-	      <xsl:otherwise>
-	          <!-- listerelation colonne unique -->
-	          <table class="{$tableClass}">
-	              <xsl:if test="lrsourcee or lrciblee">
-	                  <tr>
-	                      <xsl:if test="$numeration != '' ">
-	                          <td/>
-	                      </xsl:if>
-	                      <xsl:for-each select="lrsourcee">
-	                          <th>
-	                              <xsl:apply-templates/>
-	                          </th>
-	                      </xsl:for-each>
-	                      <xsl:for-each select="lrciblee">
-	                          <th>
-	                              <xsl:apply-templates/>
-	                          </th>
-	                      </xsl:for-each>
-	                  </tr>
-	              </xsl:if>
-	              <xsl:choose>
-	                  <xsl:when test="$type &lt; 4">
-	                      <!-- listerelation colonne unique type 1, 2 ou 3 -->
-	                      <xsl:choose>
-	                          <!-- nouveau cas -->
-	                          <xsl:when test="elemrelation">
-	                              <xsl:for-each select="elemrelation">
-	                                  <xsl:variable name="seq" select="position()"/>
-	                                  <tr>
-	                                      <xsl:if test="$numeration">
-	                                          <td class="numerotation">
-	                                              <p>
-	                                                  <xsl:choose>
-	                                                      <xsl:when test="$numeration ='decimal'">
-	                                                          <xsl:number value="$seq" format="1."/>
-	                                                      </xsl:when>
-	                                                      <xsl:when test="$numeration ='lettremaj'">
-	                                                          <xsl:number value="$seq" format="A."/>
-	                                                      </xsl:when>
-	                                                      <xsl:when test="$numeration ='lettremin'">
-	                                                          <xsl:number value="$seq" format="a."/>
-	                                                      </xsl:when>
-	                                                      <xsl:when test="$numeration ='romainmaj'">
-	                                                          <xsl:number value="$seq" format="I."/>
-	                                                      </xsl:when>
-	                                                      <xsl:when test="$numeration ='romainmin'">
-	                                                          <xsl:number value="$seq" format="i."/>
-	                                                      </xsl:when>
-	                                                  </xsl:choose>
-	                                              </p>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <xsl:if test="$nos">
-	                                          <td class="lrno">
-	                                              <p>
-	                                                  <xsl:call-template name="syntaxe_texte_affichage">
-	                                                      <xsl:with-param name="texte" select="$nos[$seq]"/>
-	                                                  </xsl:call-template>
-	                                              </p>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <xsl:for-each select="lrsource">
-	                                          <td class="lrsource">
-	                                              <xsl:apply-templates/>
-	                                          </td>
-	                                          <xsl:if test="$symbole ">
-	                                              <td class="centre_symbole">
-	                                                  <span>
-	                                                      <xsl:value-of select="$symbole"/>
-	                                                  </span>
-	                                              </td>
-	                                          </xsl:if>
-	                                      </xsl:for-each>
-	                                      <xsl:for-each select="lrcible">
-	                                          <td class="lrcible">
-	                                              <xsl:apply-templates/>
-	                                          </td>
-	                                      </xsl:for-each>
-	                                  </tr>
-	                              </xsl:for-each>
-	                          </xsl:when>
-	                          <xsl:otherwise>
-	                              <!-- ancien cas -->
-	                              <xsl:for-each select="$lrsources">
-	                                  <xsl:variable name="seq" select="position()"/>
-	                                  <tr>
-	                                      <xsl:if test="$nos">
-	                                          <td class="lrno">
-	                                              <p>
-	                                                  <xsl:call-template name="syntaxe_texte_affichage">
-	                                                      <xsl:with-param name="texte" select="$nos[$seq]"/>
-	                                                  </xsl:call-template>
-	                                              </p>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <td class="lrsource">
-	                                          <xsl:apply-templates/>
-	                                      </td>
-	                                      <xsl:if test="$symbole ">
-	                                          <td class="centre_symbole">
-	                                              <span>
-	                                                  <xsl:value-of select="$symbole"/>
-	                                              </span>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <td class="lrcible">
-	                                          <xsl:apply-templates select="$lrcibles[$seq]"/>
-	                                      </td>
-	                                  </tr>
-	                              </xsl:for-each>
-	                          </xsl:otherwise>
-	                      </xsl:choose>
-	                  </xsl:when>
-	                  <xsl:otherwise>
-	                      <!-- listerelation colonne unique type 4, 5 ou 6 -->
-	                      <xsl:choose>
-	                          <xsl:when test="elemrelation">
-	                              <xsl:for-each select="elemrelation">
-	                                  <xsl:variable name="seq" select="position()"/>
-	                                  <xsl:if test="$nos">
-	                                      <tr>
-	                                          <td class="lrno">
-	                                              <p>
-	                                                  <xsl:call-template name="syntaxe_texte_affichage">
-	                                                      <xsl:with-param name="texte" select="$nos[$seq]"/>
-	                                                  </xsl:call-template>
-	                                              </p>
-	                                          </td>
-	                                      </tr>
-	                                  </xsl:if>
-	                                  <xsl:for-each select="lrsource">
-	                                      <tr>
-	                                          <td class="lrsource">
-	                                              <xsl:apply-templates/>
-	                                          </td>
-	                                      </tr>
-	                                  </xsl:for-each>
-	                                  <xsl:for-each select="lrcible">
-	                                      <tr>
-	                                          <td class="lrcible">
-	                                              <xsl:apply-templates/>
-	                                          </td>
-	                                      </tr>
-	                                  </xsl:for-each>
-	                              </xsl:for-each>
-	                          </xsl:when>
-	                          <xsl:otherwise>
-	                              <xsl:for-each select="$lrsources">
-	                                  <xsl:variable name="seq" select="position()"/>
-	                                  <tr>
-	                                      <xsl:if test="$nos">
-	                                          <td class="lrno" rowspan="2">
-	                                              <p>
-	                                                  <xsl:call-template name="syntaxe_texte_affichage">
-	                                                      <xsl:with-param name="texte" select="$nos[$seq]"/>
-	                                                  </xsl:call-template>
-	                                              </p>
-	                                          </td>
-	                                      </xsl:if>
-	                                      <td class="lrsource">
-	                                          <xsl:apply-templates/>
-	                                      </td>
-	                                  </tr>
-	                                  <tr>
-	                                      <td class="lrcible">
-	                                          <xsl:apply-templates select="$lrcibles[$seq]"/>
-	                                      </td>
-	                                  </tr>
-	                              </xsl:for-each>
-	                          </xsl:otherwise>
-	                      </xsl:choose>
-	                  </xsl:otherwise>
-	              </xsl:choose>
-	          </table>
-	      </xsl:otherwise>
-	  </xsl:choose>
-	</xsl:template>
+  <xsl:template match="listerelation">
+    <!-- Syntaxe (#PCDATA | %texte;)* mode affichage -->
+    <xsl:variable name="type" select="@type"/>
+    <xsl:variable name="numeration" select="@numeration"/>
+    <xsl:variable name="tableClass" select="concat( 'listerelation type', $type )"/>
+    <xsl:variable name="nos" select="no"/>
+    <xsl:variable name="lrsources" select="lrsource"/>
+    <xsl:variable name="lrcibles" select="lrcible"/>
+    <xsl:variable name="symbole" select="@symbole"/>
+    <xsl:choose>
+      <xsl:when test="@nbcol">
+        <!-- listerelation colonnes multiples (2) -->
+        <xsl:variable name="nbCols" select="@nbcol"/>
+        <xsl:variable name="divClass" select="concat('nbcol', $nbCols)"/>
+        <xsl:variable name="nbElems" select="count($lrsources)"/>
+        <xsl:variable name="quotient" select="floor($nbElems div $nbCols)"/>
+        <xsl:variable name="reste" select="$nbElems mod $nbCols"/>
+        <xsl:variable name="arret1" select="$quotient + number( $reste &gt; 0 )"/>
+        <div class="multicolonne">
+          <xsl:choose>
+            <xsl:when test="$type &lt; 4">
+              <div class="{$divClass}">
+                <table class="{$tableClass}">
+                  <xsl:for-each select="$lrsources[ position() &lt;= $arret1]">
+                    <xsl:variable name="seq" select="position()"/>
+                    <tr>
+                      <xsl:if test="$nos">
+                        <td class="lrno">
+                          <p>
+                            <xsl:call-template name="syntaxe_texte_affichage">
+                              <xsl:with-param name="texte" select="$nos[$seq]"/>
+                            </xsl:call-template>
+                          </p>
+                        </td>
+                      </xsl:if>
+                      <td class="lrsource">
+                        <xsl:apply-templates/>
+                      </td>
+                      <xsl:if test="$symbole != ''">
+                        <td class="centre_symbole">
+                          <span>
+                            <xsl:value-of select="$symbole"/>
+                          </span>
+                        </td>
+                      </xsl:if>
+                      <td class="lrcible">
+                        <xsl:apply-templates select="$lrcibles[$seq]"/>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </table>
+              </div>
+              <xsl:if test="$arret1 &lt; $nbElems">
+                <div class="$divClass">
+                  <table class="{$tableClass}">
+                    <xsl:for-each select="$lrsources[ (position() &gt; $arret1) and (position() &lt;= $nbElems) ]">
+                      <xsl:variable name="seq" select="position()"/>
+                      <tr>
+                        <xsl:if test="$nos">
+                          <td class="lrno">
+                            <p>
+                              <xsl:call-template name="syntaxe_texte_affichage">
+                                <xsl:with-param name="texte" select="$nos[$arret1 + $seq]"/>
+                              </xsl:call-template>
+                            </p>
+                          </td>
+                        </xsl:if>
+                        <td class="lrsource">
+                          <xsl:apply-templates/>
+                        </td>
+                        <xsl:if test="$symbole != ''">
+                          <td class="centre_symbole">
+                            <span>
+                              <xsl:value-of select="$symbole"/>
+                            </span>
+                          </td>
+                        </xsl:if>
+                        <td class="lrcible">
+                          <xsl:apply-templates select="$lrcibles[$arret1 + $seq]"/>
+                        </td>
+                      </tr>
+                    </xsl:for-each>
+                  </table>
+                </div>
+              </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+              <div class="{$divClass}">
+                <table class="{$tableClass}">
+                  <xsl:for-each select="$lrsources[ position() &lt;= $arret1]">
+                    <xsl:variable name="seq" select="position()"/>
+                    <tr>
+                      <xsl:if test="$nos">
+                        <td class="lrno" rowspan="2">
+                          <p>
+                            <xsl:call-template name="syntaxe_texte_affichage">
+                              <xsl:with-param name="texte" select="$nos[$seq]"/>
+                            </xsl:call-template>
+                          </p>
+                        </td>
+                      </xsl:if>
+                      <td class="lrsource">
+                        <xsl:apply-templates/>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="lrcible">
+                        <xsl:apply-templates select="$lrcibles[$seq]"/>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </table>
+              </div>
+              <xsl:if test="$arret1 &lt; $nbElems">
+                <div class="{$divClass}">
+                  <table class="{$tableClass}">
+                    <xsl:for-each select="$lrsources[ (position() &gt; $arret1) and (position() &lt;= $nbElems) ]">
+                      <xsl:variable name="seq" select="position()"/>
+                      <tr>
+                        <xsl:if test="$nos">
+                          <td class="lrno" rowspan="2">
+                            <p>
+                              <xsl:call-template name="syntaxe_texte_affichage">
+                                <xsl:with-param name="texte" select="$nos[$arret1 + $seq]"/>
+                              </xsl:call-template>
+                            </p>
+                          </td>
+                        </xsl:if>
+                        <td class="lrsource">
+                          <xsl:apply-templates/>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class="lrcible">
+                          <xsl:apply-templates select="$lrcibles[$arret1 + $seq]"/>
+                        </td>
+                      </tr>
+                    </xsl:for-each>
+                  </table>
+                </div>
+              </xsl:if>
+            </xsl:otherwise>
+          </xsl:choose>
+        </div>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- listerelation colonne unique -->
+        <table class="{$tableClass}">
+          <xsl:if test="lrsourcee or lrciblee">
+            <tr>
+              <xsl:if test="$numeration != '' ">
+                <td/>
+              </xsl:if>
+              <xsl:for-each select="lrsourcee">
+                <th>
+                  <xsl:apply-templates/>
+                </th>
+              </xsl:for-each>
+              <xsl:for-each select="lrciblee">
+                <th>
+                  <xsl:apply-templates/>
+                </th>
+              </xsl:for-each>
+            </tr>
+          </xsl:if>
+          <xsl:choose>
+            <xsl:when test="$type &lt; 4">
+              <!-- listerelation colonne unique type 1, 2 ou 3 -->
+              <xsl:choose>
+                <!-- nouveau cas -->
+                <xsl:when test="elemrelation">
+                  <xsl:for-each select="elemrelation">
+                    <xsl:variable name="seq" select="position()"/>
+                    <tr>
+                      <xsl:if test="$numeration">
+                        <td class="numerotation">
+                          <p>
+                            <xsl:choose>
+                              <xsl:when test="$numeration ='decimal'">
+                                <xsl:number value="$seq" format="1."/>
+                              </xsl:when>
+                              <xsl:when test="$numeration ='lettremaj'">
+                                <xsl:number value="$seq" format="A."/>
+                              </xsl:when>
+                              <xsl:when test="$numeration ='lettremin'">
+                                <xsl:number value="$seq" format="a."/>
+                              </xsl:when>
+                              <xsl:when test="$numeration ='romainmaj'">
+                                <xsl:number value="$seq" format="I."/>
+                              </xsl:when>
+                              <xsl:when test="$numeration ='romainmin'">
+                                <xsl:number value="$seq" format="i."/>
+                              </xsl:when>
+                            </xsl:choose>
+                          </p>
+                        </td>
+                      </xsl:if>
+                      <xsl:if test="$nos">
+                        <td class="lrno">
+                          <p>
+                            <xsl:call-template name="syntaxe_texte_affichage">
+                              <xsl:with-param name="texte" select="$nos[$seq]"/>
+                            </xsl:call-template>
+                          </p>
+                        </td>
+                      </xsl:if>
+                      <xsl:for-each select="lrsource">
+                        <td class="lrsource">
+                          <xsl:apply-templates/>
+                        </td>
+                        <xsl:if test="$symbole ">
+                          <td class="centre_symbole">
+                            <span>
+                              <xsl:value-of select="$symbole"/>
+                            </span>
+                          </td>
+                        </xsl:if>
+                      </xsl:for-each>
+                      <xsl:for-each select="lrcible">
+                        <td class="lrcible">
+                          <xsl:apply-templates/>
+                        </td>
+                      </xsl:for-each>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                  <!-- ancien cas -->
+                  <xsl:for-each select="$lrsources">
+                    <xsl:variable name="seq" select="position()"/>
+                    <tr>
+                      <xsl:if test="$nos">
+                        <td class="lrno">
+                          <p>
+                            <xsl:call-template name="syntaxe_texte_affichage">
+                              <xsl:with-param name="texte" select="$nos[$seq]"/>
+                            </xsl:call-template>
+                          </p>
+                        </td>
+                      </xsl:if>
+                      <td class="lrsource">
+                        <xsl:apply-templates/>
+                      </td>
+                      <xsl:if test="$symbole ">
+                        <td class="centre_symbole">
+                          <span>
+                            <xsl:value-of select="$symbole"/>
+                          </span>
+                        </td>
+                      </xsl:if>
+                      <td class="lrcible">
+                        <xsl:apply-templates select="$lrcibles[$seq]"/>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+              <!-- listerelation colonne unique type 4, 5 ou 6 -->
+              <xsl:choose>
+                <xsl:when test="elemrelation">
+                  <xsl:for-each select="elemrelation">
+                    <xsl:variable name="seq" select="position()"/>
+                    <xsl:if test="$nos">
+                      <tr>
+                        <td class="lrno">
+                          <p>
+                            <xsl:call-template name="syntaxe_texte_affichage">
+                              <xsl:with-param name="texte" select="$nos[$seq]"/>
+                            </xsl:call-template>
+                          </p>
+                        </td>
+                      </tr>
+                    </xsl:if>
+                    <xsl:for-each select="lrsource">
+                      <tr>
+                        <td class="lrsource">
+                          <xsl:apply-templates/>
+                        </td>
+                      </tr>
+                    </xsl:for-each>
+                    <xsl:for-each select="lrcible">
+                      <tr>
+                        <td class="lrcible">
+                          <xsl:apply-templates/>
+                        </td>
+                      </tr>
+                    </xsl:for-each>
+                  </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:for-each select="$lrsources">
+                    <xsl:variable name="seq" select="position()"/>
+                    <tr>
+                      <xsl:if test="$nos">
+                        <td class="lrno" rowspan="2">
+                          <p>
+                            <xsl:call-template name="syntaxe_texte_affichage">
+                              <xsl:with-param name="texte" select="$nos[$seq]"/>
+                            </xsl:call-template>
+                          </p>
+                        </td>
+                      </xsl:if>
+                      <td class="lrsource">
+                        <xsl:apply-templates/>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="lrcible">
+                        <xsl:apply-templates select="$lrcibles[$seq]"/>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:otherwise>
+          </xsl:choose>
+        </table>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
   <!-- sources -->
   <xsl:template match="source">
-      <xsl:if test="text() or node()">
-          <p class="source">
-              <xsl:apply-templates/>
-          </p>
-      </xsl:if>
+    <xsl:if test="text() or node()">
+      <p class="source">
+        <xsl:apply-templates/>
+      </p>
+    </xsl:if>
   </xsl:template>
 
   <!-- tables -->
-	<xsl:template match="tabtexte">
-	  <xsl:variable name="valeurID" select="@id"/>
-	  <xsl:variable name="type" select="@type"/>
-	  <xsl:element name="table">
-	      <xsl:attribute name="id">
-	          <xsl:value-of select="$valeurID"/>
-	      </xsl:attribute>
-	      <xsl:attribute name="lang">
-	          <xsl:value-of select="@lang"/>
-	      </xsl:attribute>
-	      <xsl:attribute name="class">
-	          <xsl:value-of select="concat( 'tabtexte type', $type )"/>
-	      </xsl:attribute>
-	      <xsl:apply-templates/>
-	  </xsl:element>
-	</xsl:template>
-	<xsl:template name="tradAttr">
-	  <xsl:param name="noeudTab"/>
-	  <xsl:variable name="id" select="$noeudTab/@id"/>
-	  <xsl:variable name="identete" select="$noeudTab/@identete"/>
-	  <xsl:variable name="nbcol" select="$noeudTab/@nbcol"/>
-	  <xsl:variable name="nbligne" select="$noeudTab/@nbligne"/>
-	  <xsl:variable name="portee" select="$noeudTab/@portee"/>
-	  <xsl:variable name="alignh" select="$noeudTab/@alignh"/>
-	  <xsl:variable name="carac" select="$noeudTab/@carac"/>
-	  <xsl:variable name="alignv" select="$noeudTab/@alignv"/>
-	  <xsl:if test="$id">
-	      <xsl:attribute name="id">
-	          <xsl:value-of select="$id"/>
-	      </xsl:attribute>
-	  </xsl:if>
-	  <xsl:if test="$identete">
-	      <xsl:attribute name="headers">
-	          <xsl:value-of select="$identete"/>
-	      </xsl:attribute>
-	  </xsl:if>
-	  <xsl:if test="$nbcol">
-	      <xsl:choose>
-	          <xsl:when test="$noeudTab/self::tabgrcol">
-	              <xsl:attribute name="colspan">
-	                  <xsl:value-of select="$nbcol"/>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:otherwise>
-	              <xsl:attribute name="colspan">
-	                  <xsl:value-of select="$nbcol"/>
-	              </xsl:attribute>
-	          </xsl:otherwise>
-	      </xsl:choose>
-	  </xsl:if>
-	  <xsl:if test="$nbligne">
-	      <xsl:attribute name="rowspan">
-	          <xsl:value-of select="$nbligne"/>
-	      </xsl:attribute>
-	  </xsl:if>
-	  <xsl:if test="$portee">
-	      <xsl:choose>
-	          <xsl:when test="$portee = 'ligne'">
-	              <xsl:attribute name="scope">
-	                  <xsl:text>row</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$portee = 'colonne'">
-	              <xsl:attribute name="scope">
-	                  <xsl:text>col</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$portee = 'grligne'">
-	              <xsl:attribute name="scope">
-	                  <xsl:text>rowgroup</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$portee = 'grcolonne'">
-	              <xsl:attribute name="scope">
-	                  <xsl:text>colgroup</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	      </xsl:choose>
-	  </xsl:if>
-	  <xsl:if test="$alignh">
-	      <xsl:choose>
-	          <xsl:when test="$alignh = 'gauche'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>text-align: left;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignh = 'centre'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>text-align: center;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignh = 'droite'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>text-align: right;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignh = 'justifie'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>text-align: justify;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignh = 'carac'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>char</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	      </xsl:choose>
-	  </xsl:if>
-	  <xsl:if test="$carac">
-	      <xsl:attribute name="char">
-	          <xsl:value-of select="$carac"/>
-	      </xsl:attribute>
-	  </xsl:if>
-	  <xsl:if test="$alignv">
-	      <xsl:choose>
-	          <xsl:when test="$alignv = 'haut'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>vertical-align: top;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignv = 'centre'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>vertical-align: middle;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignv = 'bas'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>vertical-align: bottom;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	          <xsl:when test="$alignv = 'lignebase'">
-	              <xsl:attribute name="style">
-	                  <xsl:text>vertical-align: baseline;</xsl:text>
-	              </xsl:attribute>
-	          </xsl:when>
-	      </xsl:choose>
-	  </xsl:if>
-	</xsl:template>
-	<xsl:template match="tabcol">
-	  <xsl:element name="col">
-	      <xsl:call-template name="tradAttr">
-	          <xsl:with-param name="noeudTab" select="."/>
-	      </xsl:call-template>
-	  </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabgrcol">
-	    <xsl:element name="colgroup">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- tabcol* -->
-	    </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabentete">
-	    <xsl:element name="thead">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- tabligne+ -->
-	    </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabligne">
-	    <xsl:element name="tr">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- (tabcellulee | tabcelluled)+ -->
-	    </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabcelluled">
-	    <xsl:element name="td">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- blocimbrique+ -->
-	    </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabcellulee">
-	    <xsl:element name="th">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- blocimbrique+ -->
-	    </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabpied">
-	    <xsl:element name="tfoot">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- tabligne+ -->
-	    </xsl:element>
-	</xsl:template>
-	<xsl:template match="tabgrligne">
-	    <xsl:element name="tbody">
-	        <xsl:call-template name="tradAttr">
-	            <xsl:with-param name="noeudTab" select="."/>
-	        </xsl:call-template>
-	        <xsl:apply-templates/>
-	        <!-- tabligne+ -->
-	    </xsl:element>
-	</xsl:template>
+  <xsl:template match="tabtexte">
+    <xsl:variable name="valeurID" select="@id"/>
+    <xsl:variable name="type" select="@type"/>
+    <xsl:element name="table">
+      <xsl:attribute name="id">
+        <xsl:value-of select="$valeurID"/>
+      </xsl:attribute>
+      <xsl:attribute name="lang">
+        <xsl:value-of select="@lang"/>
+      </xsl:attribute>
+      <xsl:attribute name="class">
+        <xsl:value-of select="concat( 'tabtexte type', $type )"/>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+  <xsl:template name="tradAttr">
+    <xsl:param name="noeudTab"/>
+    <xsl:variable name="id" select="$noeudTab/@id"/>
+    <xsl:variable name="identete" select="$noeudTab/@identete"/>
+    <xsl:variable name="nbcol" select="$noeudTab/@nbcol"/>
+    <xsl:variable name="nbligne" select="$noeudTab/@nbligne"/>
+    <xsl:variable name="portee" select="$noeudTab/@portee"/>
+    <xsl:variable name="alignh" select="$noeudTab/@alignh"/>
+    <xsl:variable name="carac" select="$noeudTab/@carac"/>
+    <xsl:variable name="alignv" select="$noeudTab/@alignv"/>
+    <xsl:if test="$id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="$id"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="$identete">
+      <xsl:attribute name="headers">
+        <xsl:value-of select="$identete"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="$nbcol">
+      <xsl:choose>
+        <xsl:when test="$noeudTab/self::tabgrcol">
+          <xsl:attribute name="colspan">
+            <xsl:value-of select="$nbcol"/>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="colspan">
+            <xsl:value-of select="$nbcol"/>
+          </xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+    <xsl:if test="$nbligne">
+      <xsl:attribute name="rowspan">
+        <xsl:value-of select="$nbligne"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="$portee">
+      <xsl:choose>
+        <xsl:when test="$portee = 'ligne'">
+          <xsl:attribute name="scope">
+            <xsl:text>row</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$portee = 'colonne'">
+          <xsl:attribute name="scope">
+            <xsl:text>col</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$portee = 'grligne'">
+          <xsl:attribute name="scope">
+            <xsl:text>rowgroup</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$portee = 'grcolonne'">
+          <xsl:attribute name="scope">
+            <xsl:text>colgroup</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:if>
+    <xsl:if test="$alignh">
+      <xsl:choose>
+        <xsl:when test="$alignh = 'gauche'">
+          <xsl:attribute name="style">
+            <xsl:text>text-align: left;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignh = 'centre'">
+          <xsl:attribute name="style">
+            <xsl:text>text-align: center;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignh = 'droite'">
+          <xsl:attribute name="style">
+            <xsl:text>text-align: right;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignh = 'justifie'">
+          <xsl:attribute name="style">
+            <xsl:text>text-align: justify;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignh = 'carac'">
+          <xsl:attribute name="style">
+            <xsl:text>char</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:if>
+    <xsl:if test="$carac">
+      <xsl:attribute name="char">
+        <xsl:value-of select="$carac"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="$alignv">
+      <xsl:choose>
+        <xsl:when test="$alignv = 'haut'">
+          <xsl:attribute name="style">
+            <xsl:text>vertical-align: top;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignv = 'centre'">
+          <xsl:attribute name="style">
+            <xsl:text>vertical-align: middle;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignv = 'bas'">
+          <xsl:attribute name="style">
+            <xsl:text>vertical-align: bottom;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$alignv = 'lignebase'">
+          <xsl:attribute name="style">
+            <xsl:text>vertical-align: baseline;</xsl:text>
+          </xsl:attribute>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template match="tabcol">
+    <xsl:element name="col">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabgrcol">
+    <xsl:element name="colgroup">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- tabcol* -->
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabentete">
+    <xsl:element name="thead">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- tabligne+ -->
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabligne">
+    <xsl:element name="tr">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- (tabcellulee | tabcelluled)+ -->
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabcelluled">
+    <xsl:element name="td">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- blocimbrique+ -->
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabcellulee">
+    <xsl:element name="th">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- blocimbrique+ -->
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabpied">
+    <xsl:element name="tfoot">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- tabligne+ -->
+    </xsl:element>
+  </xsl:template>
+  <xsl:template match="tabgrligne">
+    <xsl:element name="tbody">
+      <xsl:call-template name="tradAttr">
+        <xsl:with-param name="noeudTab" select="."/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <!-- tabligne+ -->
+    </xsl:element>
+  </xsl:template>
 
   <!--*** APPPENDIX ***-->
   <xsl:template match="partiesann">
@@ -1772,158 +1765,158 @@
   </xsl:template>
 
   <xsl:template match="grannexe | merci | grnotebio | grnote | grbiblio">
-      <section id="{name()}" class="article-section {name()}" role="complementary">
-          <h2>
-              <xsl:choose>
-                  <xsl:when test="self::grannexe">
-                      <xsl:apply-templates select="self::grannexe" mode="toc-heading"/>
-                  </xsl:when>
-                  <xsl:when test="self::merci">
-                      <xsl:apply-templates select="self::merci" mode="toc-heading"/>
-                  </xsl:when>
-                  <xsl:when test="self::grnotebio">
-                      <xsl:apply-templates select="self::grnotebio" mode="toc-heading"/>
-                  </xsl:when>
-                  <xsl:when test="self::grnote">
-                      <xsl:apply-templates select="self::grnote" mode="toc-heading"/>
-                  </xsl:when>
-                  <xsl:when test="self::grbiblio">
-                      <xsl:apply-templates select="self::grbiblio" mode="toc-heading"/>
-                  </xsl:when>
-              </xsl:choose>
-          </h2>
-          <xsl:choose>
-            <xsl:when test="self::grnote | self::grbiblio">
-              <ol class="unstyled">
-                <xsl:apply-templates select="*[not(self::titre)]"/>
-              </ol>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:apply-templates select="*[not(self::titre)]"/>
-            </xsl:otherwise>
-          </xsl:choose>
-      </section>
+    <section id="{name()}" class="article-section {name()}" role="complementary">
+      <h2>
+        <xsl:choose>
+          <xsl:when test="self::grannexe">
+            <xsl:apply-templates select="self::grannexe" mode="toc-heading"/>
+          </xsl:when>
+          <xsl:when test="self::merci">
+            <xsl:apply-templates select="self::merci" mode="toc-heading"/>
+          </xsl:when>
+          <xsl:when test="self::grnotebio">
+            <xsl:apply-templates select="self::grnotebio" mode="toc-heading"/>
+          </xsl:when>
+          <xsl:when test="self::grnote">
+            <xsl:apply-templates select="self::grnote" mode="toc-heading"/>
+          </xsl:when>
+          <xsl:when test="self::grbiblio">
+            <xsl:apply-templates select="self::grbiblio" mode="toc-heading"/>
+          </xsl:when>
+        </xsl:choose>
+      </h2>
+      <xsl:choose>
+        <xsl:when test="self::grnote | self::grbiblio">
+          <ol class="unstyled">
+            <xsl:apply-templates select="*[not(self::titre)]"/>
+          </ol>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="*[not(self::titre)]"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </section>
   </xsl:template>
 
   <!-- appendices / supplements -->
   <xsl:template match="annexe">
-      <div class="article-section-content" role="subsection">
-          <xsl:if test="no or titre">
-              <h4 class="titreann">
-                  <xsl:if test="titre and no">
-                      <xsl:apply-templates select="no"/>
-                      <xsl:text>. </xsl:text>
-                  </xsl:if>
-                  <xsl:if test="titre">
-                      <xsl:apply-templates select="titre"/>
-                  </xsl:if>
-                  <xsl:if test="no and not(titre)">
-                      <xsl:apply-templates select="no"/>
-                  </xsl:if>
-              </h4>
+    <div class="article-section-content" role="subsection">
+      <xsl:if test="no or titre">
+        <h4 class="titreann">
+          <xsl:if test="titre and no">
+            <xsl:apply-templates select="no"/>
+            <xsl:text>. </xsl:text>
           </xsl:if>
-          <xsl:apply-templates select="section1"/>
-          <xsl:apply-templates select="noteann"/>
-      </div>
+          <xsl:if test="titre">
+            <xsl:apply-templates select="titre"/>
+          </xsl:if>
+          <xsl:if test="no and not(titre)">
+            <xsl:apply-templates select="no"/>
+          </xsl:if>
+        </h4>
+      </xsl:if>
+      <xsl:apply-templates select="section1"/>
+      <xsl:apply-templates select="noteann"/>
+    </div>
   </xsl:template>
 
   <!-- notes within appendices -->
   <xsl:template match="noteann">
-      <div class="{name()}">
-          <xsl:apply-templates/>
-      </div>
+    <div class="{name()}">
+      <xsl:apply-templates/>
+    </div>
   </xsl:template>
 
   <xsl:template match="noteann/no">
-      <a class="renote">
-          <xsl:attribute name="href">#re1
-              <xsl:value-of select="../@id"/>
-          </xsl:attribute>
-          <xsl:attribute name="id">
-              <xsl:value-of select="../@id"/>
-          </xsl:attribute>
-        [
-          <xsl:apply-templates/>]
+    <a class="renote">
+      <xsl:attribute name="href">#re1
+        <xsl:value-of select="../@id"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="../@id"/>
+      </xsl:attribute>
+      [
+      <xsl:apply-templates/>]
 
-      </a>
+    </a>
   </xsl:template>
 
   <!-- biographical notes -->
   <xsl:template match="notebio">
-      <div class="notebio">
-          <xsl:apply-templates/>
-      </div>
+    <div class="notebio">
+      <xsl:apply-templates/>
+    </div>
   </xsl:template>
 
   <xsl:template match="notebio/nompers">
-      <h2 class="nompers">
-          <xsl:apply-templates/>
-      </h2>
+    <h2 class="nompers">
+      <xsl:apply-templates/>
+    </h2>
   </xsl:template>
 
   <!-- footnotes -->
   <xsl:template match="note">
-      <li class="note" id="{@id}">
-          <xsl:if test="no">
-              <a href="#re1{@id}" class="nonote">
-                  <xsl:text>[</xsl:text><xsl:apply-templates select="no"/><xsl:text>]</xsl:text>
-              </a>
-          </xsl:if>
-          <xsl:apply-templates select="alinea" mode="numero"/>
-          <xsl:apply-templates select="*[not(self::alinea)][not(self::no)]"/>
-      </li>
+    <li class="note" id="{@id}">
+      <xsl:if test="no">
+        <a href="#re1{@id}" class="nonote">
+          <xsl:text>[</xsl:text><xsl:apply-templates select="no"/><xsl:text>]</xsl:text>
+        </a>
+      </xsl:if>
+      <xsl:apply-templates select="alinea" mode="numero"/>
+      <xsl:apply-templates select="*[not(self::alinea)][not(self::no)]"/>
+    </li>
   </xsl:template>
   <xsl:template match="alinea" mode="numero">
-      <span class="alinea">
-          <xsl:apply-templates/>
-      </span>
+    <span class="alinea">
+      <xsl:apply-templates/>
+    </span>
   </xsl:template>
   <xsl:template match="renvoi">
-      <xsl:text>&#160;</xsl:text>
-      <xsl:element name="a">
-        <xsl:attribute name="href">
-          <xsl:text>#</xsl:text><xsl:value-of select="@idref"/>
-        </xsl:attribute>
-        <xsl:attribute name="id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-        <xsl:attribute name="class">
-          <xsl:text>norenvoi hint--bottom hint--no-animate</xsl:text>
-        </xsl:attribute>
-        <xsl:attribute name="data-hint">
-          <xsl:variable name="idref" select="@idref"/>
-          <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)], 1, 200)"/>
-          <xsl:if test="string-length(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)]) &gt; 200">
-            <xsl:text>[…]</xsl:text>
-          </xsl:if>
-        </xsl:attribute>
-        <xsl:text>[</xsl:text>
-        <xsl:value-of select="normalize-space()"/>
-        <xsl:text>]</xsl:text>
-      </xsl:element>
+    <xsl:text>&#160;</xsl:text>
+    <xsl:element name="a">
+      <xsl:attribute name="href">
+        <xsl:text>#</xsl:text><xsl:value-of select="@idref"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+      <xsl:attribute name="class">
+        <xsl:text>norenvoi hint--bottom hint--no-animate</xsl:text>
+      </xsl:attribute>
+      <xsl:attribute name="data-hint">
+        <xsl:variable name="idref" select="@idref"/>
+        <xsl:value-of select="substring(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)], 1, 200)"/>
+        <xsl:if test="string-length(/article/partiesann/grnote/note[@id=$idref]/*[not(self::no)]) &gt; 200">
+          <xsl:text>[…]</xsl:text>
+        </xsl:if>
+      </xsl:attribute>
+      <xsl:text>[</xsl:text>
+      <xsl:value-of select="normalize-space()"/>
+      <xsl:text>]</xsl:text>
+    </xsl:element>
   </xsl:template>
 
   <xsl:template match="notefig|notetabl">
-      <div class="notefigtab">
-          <xsl:if test="no">
-              <a href="#re1{@id}" id="{@id}" class="nonote">
-                  <xsl:apply-templates select="no"/>
-              </a>
-          </xsl:if>
-          <xsl:apply-templates select="*[not(self::no)]"/>
-      </div>
+    <div class="notefigtab">
+      <xsl:if test="no">
+        <a href="#re1{@id}" id="{@id}" class="nonote">
+          <xsl:apply-templates select="no"/>
+        </a>
+      </xsl:if>
+      <xsl:apply-templates select="*[not(self::no)]"/>
+    </div>
   </xsl:template>
 
   <xsl:template match="tableau//notefig|tableau//notetabl|figure//notefig|figure//notetabl">
-      <div class="notefigtab">
-          <xsl:apply-templates/>
-      </div>
+    <div class="notefigtab">
+      <xsl:apply-templates/>
+    </div>
   </xsl:template>
 
   <xsl:template match="notefig/no|notetabl/no">
-      <sup class="notefigtab" id="{../@id}">
-          <xsl:apply-templates/>
-      </sup>
+    <sup class="notefigtab" id="{../@id}">
+      <xsl:apply-templates/>
+    </sup>
   </xsl:template>
 
   <!-- bibliography -->
@@ -1937,26 +1930,26 @@
     </li>
   </xsl:template>
   <xsl:template match="biblio/titre">
-      <h5 class="{name()}">
-          <xsl:apply-templates/>
-      </h5>
+    <h5 class="{name()}">
+      <xsl:apply-templates/>
+    </h5>
   </xsl:template>
   <xsl:template match="refbiblio">
-      <xsl:variable name="valeurNO" select="no"/>
-      <li class="refbiblio" role="note">
-          <a class="no" id="{@id}">
-              <xsl:choose>
-                  <xsl:when test="$valeurNO">
-                      <xsl:apply-templates select="$valeurNO"/>
-                      <xsl:text>.</xsl:text>
-                  </xsl:when>
-                  <xsl:otherwise></xsl:otherwise>
-              </xsl:choose>
-          </a>
-          <xsl:apply-templates select="node()[name() != 'idpublic' and name() != 'no']"/>
-          <xsl:text></xsl:text>
-          <xsl:apply-templates select="idpublic"/>
-      </li>
+    <xsl:variable name="valeurNO" select="no"/>
+    <li class="refbiblio" role="note">
+      <a class="no" id="{@id}">
+        <xsl:choose>
+          <xsl:when test="$valeurNO">
+            <xsl:apply-templates select="$valeurNO"/>
+            <xsl:text>.</xsl:text>
+          </xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+      </a>
+      <xsl:apply-templates select="node()[name() != 'idpublic' and name() != 'no']"/>
+      <xsl:text></xsl:text>
+      <xsl:apply-templates select="idpublic"/>
+    </li>
   </xsl:template>
 
   <!--*** LISTS OF TABLES & FIGURES ***-->
@@ -2055,65 +2048,65 @@
   </xsl:template>
 
   <!-- element_nompers_affichage -->
-	<xsl:template name="element_nompers_affichage">
-		<xsl:param name="nompers"/>
-		<xsl:if test="$nompers[@typenompers = 'pseudonyme']">
+  <xsl:template name="element_nompers_affichage">
+    <xsl:param name="nompers"/>
+    <xsl:if test="$nompers[@typenompers = 'pseudonyme']">
       <xsl:text> </xsl:text>
-			<xsl:text>{% trans "alias" %}</xsl:text>
+      <xsl:text>{% trans "alias" %}</xsl:text>
       <xsl:text> </xsl:text>
-		</xsl:if>
-		<xsl:if test="$nompers/prefixe/node()">
-			<xsl:call-template name="syntaxe_texte_affichage">
-				<xsl:with-param name="texte" select="$nompers/prefixe"/>
-			</xsl:call-template>
-			<xsl:text>
-			</xsl:text>
-		</xsl:if>
-		<xsl:if test="$nompers/prenom/node()">
-			<xsl:call-template name="syntaxe_texte_affichage">
-				<xsl:with-param name="texte" select="$nompers/prenom"/>
-			</xsl:call-template>
-		</xsl:if>
-		<xsl:if test="$nompers/autreprenom/node()">
-			<xsl:text>
-			</xsl:text>
-			<xsl:call-template name="syntaxe_texte_affichage">
-				<xsl:with-param name="texte" select="$nompers/autreprenom"/>
-			</xsl:call-template>
-		</xsl:if>
-		<xsl:if test="$nompers/nomfamille/node()">
-			<xsl:text>
-			</xsl:text>
-			<xsl:call-template name="syntaxe_texte_affichage">
-				<xsl:with-param name="texte" select="$nompers/nomfamille"/>
-			</xsl:call-template>
-		</xsl:if>
-		<xsl:for-each select="$nompers/suffixe[child::node()]">
-			<xsl:text>, </xsl:text>
-			<xsl:call-template name="syntaxe_texte_affichage">
-				<xsl:with-param name="texte" select="."/>
-			</xsl:call-template>
-		</xsl:for-each>
-	</xsl:template>
+    </xsl:if>
+    <xsl:if test="$nompers/prefixe/node()">
+      <xsl:call-template name="syntaxe_texte_affichage">
+        <xsl:with-param name="texte" select="$nompers/prefixe"/>
+      </xsl:call-template>
+      <xsl:text>
+      </xsl:text>
+    </xsl:if>
+    <xsl:if test="$nompers/prenom/node()">
+      <xsl:call-template name="syntaxe_texte_affichage">
+        <xsl:with-param name="texte" select="$nompers/prenom"/>
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:if test="$nompers/autreprenom/node()">
+      <xsl:text>
+      </xsl:text>
+      <xsl:call-template name="syntaxe_texte_affichage">
+        <xsl:with-param name="texte" select="$nompers/autreprenom"/>
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:if test="$nompers/nomfamille/node()">
+      <xsl:text>
+      </xsl:text>
+      <xsl:call-template name="syntaxe_texte_affichage">
+        <xsl:with-param name="texte" select="$nompers/nomfamille"/>
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:for-each select="$nompers/suffixe[child::node()]">
+      <xsl:text>, </xsl:text>
+      <xsl:call-template name="syntaxe_texte_affichage">
+        <xsl:with-param name="texte" select="."/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
 
-	<!-- syntaxe_texte_affichage -->
-	<xsl:template name="syntaxe_texte_affichage">
-		<xsl:param name="texte" select="."/>
-		<xsl:for-each select="$texte/node()">
-			<xsl:choose>
-				<!-- #PCDATA -->
-				<xsl:when test="self::text()">
-					<xsl:value-of select="."/>
-				</xsl:when>
-				<!-- %texte -->
-				<xsl:otherwise>
-					<xsl:call-template name="entite_texte_affichage">
-						<xsl:with-param name="texte" select="."/>
-					</xsl:call-template>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:for-each>
-	</xsl:template>
+  <!-- syntaxe_texte_affichage -->
+  <xsl:template name="syntaxe_texte_affichage">
+    <xsl:param name="texte" select="."/>
+    <xsl:for-each select="$texte/node()">
+      <xsl:choose>
+        <!-- #PCDATA -->
+        <xsl:when test="self::text()">
+          <xsl:value-of select="."/>
+        </xsl:when>
+        <!-- %texte -->
+        <xsl:otherwise>
+          <xsl:call-template name="entite_texte_affichage">
+            <xsl:with-param name="texte" select="."/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:template>
 
   <!-- entite_texte_affichage -->
   <xsl:template name="entite_texte_affichage">


### PR DESCRIPTION
- Style all quotation-like elements
- Add tooltips with previous and next article titles

## Epigraphs
- [At the beginning of an article](http://localhost:8000/fr/revues/vi/2011-v37-n1-n1/1006460ar/#corps) ("La forme graphique redouble le sens du mot ; verbal et non verbal disent la même pensée  [1].")
- [In the body of an article](http://localhost:8000/fr/revues/mlj/2013-v59-n1-n1/1018985ar/#s3n4) ("Tsige argues that it is not open to this court to adapt the common law to deal with the invasion of privacy. [...]")

## Dedications
- [Dedication ("En mémoire de Dominique Dormont (1948-2003)") followed by an epigraph ("« Être vivant, c’est être fait de mémoire »") with a source](http://localhost:8000/fr/revues/ms/2004-v20-n5-n5/008407ar/)

## Block quotes
- [At the beginning of an article, with a source](http://localhost:8000/fr/revues/ateliers/2013-v8-n2-n2/1021334ar/#s1n1) ("In formulating such a conception [of justice], political liberalism applies the principle of toleration to philosophy itself.")
- [Containing an ordered list](http://localhost:8000/fr/revues/crimino/2011-v44-n2-n2/1005791ar/#pa7) ("Le terme « victime » s’entend de toute personne physique qui a subi un préjudice du fait de la commission d’un crime relevant de la compétence de la Cour ; [...]")
- [Within a footnote](http://localhost:8000/fr/revues/crimino/2011-v44-n2-n2/1005791ar/#no7) ("Si, à un moment quelconque du procès, la Chambre se rend compte que la qualification juridique des faits peut être modifiée [...]")
- [Containing a footnote](http://localhost:8000/fr/revues/crimino/2011-v44-n2-n2/1005792ar/#pa6) ([...]  leur rôle et leurs objectifs étant clairement distincts [7].)
- [Multiple quotations, in Japanese, with page number as sources and interspersed with the author's notes in brackets](http://localhost:8000/fr/revues/ttr/2010-v23-n2-n2/1009160ar/#pa21) ("In its highest form, politeness almost approaches love. [...] [“Politeness is very patient and is good; is not envious, does not boast, never says but; does not behave in an improper way, does not think of herself, is not easily angered and pays no attention to evil”]")

## Verbatims
- [With source and footnote](http://localhost:8000/fr/revues/dss/2010-v9-n2-n2/1005299ar/#pa18) ("… C’est sûr que j’en prends vraiment plus beaucoup [...]")
- [No source](http://localhost:8000/fr/revues/ttr/2009-v22-n1-n1/044787ar/#pa10) ("Shall I compare thee to a summer’s day?")
- [Containing two blocks (= paragraphs)](http://localhost:8000/fr/revues/ravon/2009-n56-n56/1001094ar/#pa14) ("Then rising haughtily he glanced around")
- [Monospaced, `typeverb="formeef"`](http://localhost:8000/revue/meta/2011/v56/n2/1006180ar.html#pa55) ("“Avec RevitaLift Rides de Cassure, mon visage est moins dur, [...]")
- [Poem, `typeverb="poeme"`](http://localhost:8000/fr/revues/etudfr/2011-v47-n3-n3/1006446ar/#pa1) - no specific formatting, compare with [current website](http://www.erudit.org/revue/etudfr/2011/v47/n3/1006446ar.html#pa1) - see the second blockquote ("Quant je pensoye à la dame sus dicte"), not the first
- [_Word for word_ (?), `typeverb="motpourmot"`](http://localhost:8000/fr/revues/nps/2010-v23-n1-n1/1003166ar/#pa15) - no specific formatting, compare with [current website](http://www.erudit.org/revue/nps/2010/v23/n1/1003166ar.html#pa15) ("Le projet m’aide beaucoup.")
- [Dialogue, `typeverb="dialogue"`](http://localhost:8000/fr/revues/nps/2011-v23-n2-n2/1006128ar/#pa19) - no specific formatting, compare with [current website](http://www.erudit.org/revue/nps/2011/v23/n2/1006128ar.html#pa19) ("Question – C’est quoi le genre d’affaires que Danielle peut plus [davantage] décider ?")
- [_Form_ (?), `typeverb="forme"](http://localhost:8000/fr/revues/vi/2011-v37-n1-n1/1006460ar/#pa2) - no specific formatting, compare with [current website](http://www.erudit.org/revue/vi/2011/v37/n1/1006460ar.html#pa2) ("Écrire un livre où n’y aurait rien que ce clair dépouillement plein de choses dont je rêve. ")
- [Poem with horizontal spacing, `espaceh`](http://localhost:8000/fr/revues/ravon/2009-n56-n56/1001092ar/#pa43) - style is inline, exact value of spacing is in XML... see the [current website](http://www.erudit.org/revue/ravon/2009/v/n56/1001092ar.html#pa43) (" We are surrounded with")
- [Poem with vertical spacing, `espacev`](http://localhost:8000/fr/revues/ttr/2012-v25-n2-n2/1018807ar/#pa8) - style is also inline, exact value of spacing is in XML... see the [current website](http://www.erudit.org/revue/ttr/2012/v25/n2/1018807ar.html#pa8) ("TRANSLATION EXERCISE #1:")