### PR TITLE
#2106 - Issue title pages

### DIFF
--- a/eruditorg/static/js/controllers/public/journal/JournalDetailController.js
+++ b/eruditorg/static/js/controllers/public/journal/JournalDetailController.js
@@ -1,24 +1,25 @@
 export default {
 
   init: function() {
-    this.smoothScroll();
+    this.article = $('#journal_detail');
+    this.sticky_header_height = 0;
+
+    this.smooth_scroll();
   },
 
-  smoothScroll: function() {
+  smooth_scroll : function () {
+    this.article.on('click', 'a[href*="#"]', (e) => {
+      if( e ) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
 
-    $('a[href^="#"]').on('click',function (e) {
-      e.preventDefault();
-      var target = this.hash;
-      var $target = $(target);
+      var target = $(e.currentTarget).attr('href').replace('#', '');
+      if( !target ) return false;
 
-      $('html, body').stop().animate({
-        'scrollTop': $target.offset().top
-      }, 900, 'swing', function () {
-        window.location.hash = target;
-      });
-
+      $('html, body').animate( { scrollTop: this.article.find('#'+target).offset().top - this.sticky_header_height - 30 }, 750 );
+      return false;
     });
-
   },
 
 };

--- a/eruditorg/static/sass/pages/public/_homepage.scss
+++ b/eruditorg/static/sass/pages/public/_homepage.scss
@@ -165,7 +165,6 @@
       img {
         width: 100%;
         margin-bottom: 10px;
-        border: 1px solid $mid-grey;
       }
 
       .category-tag {
@@ -175,6 +174,7 @@
       .latest-issues--article--cover {
         height: 140px;
         width: auto;
+        border: 1px solid $mid-grey;
       }
 
       .latest-issues--article--logo {

--- a/eruditorg/static/sass/pages/public/_issue-detail.scss
+++ b/eruditorg/static/sass/pages/public/_issue-detail.scss
@@ -6,6 +6,7 @@
   .page-header-main {
 
     h1 {
+      font-size: 1.953em;
 
       .ion-locked {
         font-size: 0.5em;
@@ -16,8 +17,9 @@
     }
 
     h2 {
-      @include fw-sans();
-      margin-bottom: 1em;
+      margin: 1.5em 0 0.75em 0;
+      color: $dark-grey;
+      @include font-styles('sans');
     }
 
   }

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -101,7 +101,7 @@
         {% if forloop.first %}</span>
         {% endif %}
       {% endfor %}
-      <span>{{ issue.volume_title_with_pages }}{% if issue.has_movable_limitation and not user_has_access_to_journal %}&nbsp;<span class="hint--top hint--no-animate" data-hint="{% trans 'L’accès aux numéros courants de ce numéro nécessite un abonnement.' %}"><span class="ion-locked"></span></span>{% endif %}</span>
+      <span>{{ issue.volume_title }}{% if issue.has_movable_limitation and not user_has_access_to_journal %}&nbsp;<span class="hint--top hint--no-animate" data-hint="{% trans 'L’accès aux numéros courants de ce numéro nécessite un abonnement.' %}"><span class="ion-locked"></span></span>{% endif %}</span>
     </h1>
     <h2>
       {% trans "Sommaire" %} ({{ articles|length }} {% trans "articles" %}){% if issue.journal.collection.code == 'unb' %}&nbsp;<span class="hint--top hint--no-animate" data-hint="{% trans 'La lecture de ces articles nécessite la redirection vers le site de la revue.' %}"><span class="ion-alert"></span></span>{% endif %}
@@ -187,6 +187,7 @@
 
 {% block aside_issue %}
 <h2><a href="{% url 'public:journal:journal_detail' journal.code %}" title="{% trans 'Consulter la revue' %}">{{ issue.journal.name }}</a></h2>
+<p>{{ issue.volume_title_with_pages }}</p>
 {% if issue.has_coverpage %}
 <div>
   <img src="{% url 'public:journal:issue_coverpage' issue.journal.code issue.volume_slug issue.localidentifier %}" class="img-responsive issue-coverpage" alt="{% trans 'Couverture de' %} {% if issue.html_title %}{{ issue.html_title|safe }}, {% endif %}

--- a/eruditorg/templates/public/journal/journal_base.html
+++ b/eruditorg/templates/public/journal/journal_base.html
@@ -39,7 +39,8 @@
         {% endif %}
         {% endblock aside_issue %}
         <p>
-          <a href="{% url 'public:journal:journal_detail' journal.code %}#back-issues" class="btn btn-primary see-issues-btn" title="{% trans 'Historique de la revue' %}">
+          {% url 'public:journal:journal_detail' journal.code as journal_detail_url %}
+          <a href="{% if request.get_full_path != journal_detail_url %}{{ journal_detail_url }}{% endif %}#back-issues" class="btn btn-primary see-issues-btn" title="{% trans 'Historique de la revue' %}">
             {% trans "Voir tous les numéros" %}
           </a>
         </p>


### PR DESCRIPTION
Issue title / headings were too long and took up too much space "above the fold" - remove pagination (this info is not useful there), move this info in the sidebar, reduce size and contrast of issue page headings.

Compare with preprod:
- [Ville durable et changement climatique](http://localhost:8000/fr/revues/eue/2011-v5-eue1818520/) vs [preprod](http://preprod.erudit.org/fr/revues/eue/2011-v5-eue1818520/) 
- [Volume 75, numéro hors série, 2009](http://localhost:8000/fr/revues/ehr/2009-v75-ehr3472/) vs [preprod](http://preprod.erudit.org/fr/revues/ehr/2009-v75-ehr3472/)
- [Volume 16, numéro 2, Hiver 2012](http://localhost:8000/fr/revues/mi/2012-v16-n2-mi061/) vs [preprod](http://preprod.erudit.org/fr/revues/mi/2012-v16-n2-mi061/)