### PR TITLE
SEO / ASEO for abstract and article pages

### DIFF
--- a/eruditorg/static/sass/components/article/_abstracts.scss
+++ b/eruditorg/static/sass/components/article/_abstracts.scss
@@ -3,11 +3,10 @@
  */
 
 .grresume {
-  margin-top: $margin-vertical-default;
+  padding-bottom: $padding-vertical-default;
   border-bottom: 1px solid #000;
 
   > .resume {
-    margin: $margin-vertical-default*1.5 0;
 
     h2, h3 {
       color: #333;
@@ -29,10 +28,15 @@
       h2 {
         border-top: 0;
         padding-top: 0;
+        margin-top: 0;
       }
 
     }
 
+  }
+
+  &:last-of-type {
+    border: none;
   }
 
 }

--- a/eruditorg/static/sass/components/article/_bibliographies.scss
+++ b/eruditorg/static/sass/components/article/_bibliographies.scss
@@ -15,13 +15,35 @@
 
      a {
        font-size: 12px;
-       @include fw-mono;
+       
+       &:hover, &:focus, &:active {
+         color: $coral-red;
+         text-decoration: none;
+       }
+
      }
 
      .no {
        margin-right: 0.25em;
      }
 
+   }
+
+   .idpublic {
+     @include fw-mono;
+   }
+
+   .refbiblio-links {
+     margin-bottom: 1em;
+   }
+
+   .refbiblio-link {
+     margin-right: 1em;
+     color: #000;
+   }
+
+   .scholar-link {
+     background-image: linear-gradient(to top, #fff, #FFF 1px, $coral-red 1px, $coral-red 1px, #FFF 2px);
    }
 
  }

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -61,6 +61,7 @@ $article-toolbar-width: 80px;
     }
 
     .btn.btn-primary{
+      float: right;
       color: $white;
 
       &:hover, &:focus, &:active {
@@ -115,6 +116,12 @@ $article-toolbar-width: 80px;
 
     .title-tag {
       margin-top: 0;
+    }
+
+    .title-summary {
+      color: $coral-red;
+      text-transform: uppercase;
+      @include fw-sans-medium;
     }
 
     .surtitre,
@@ -438,12 +445,6 @@ $article-toolbar-width: 80px;
 
     }
 
-    // headings within the article
-    h2 {
-      border-top: 1px solid $mid-grey;
-      padding-top: 1em;
-    }
-
     h2, h3, h4, h5, h6, .h7 {
       @include fw-serif-bold();
       margin-top: 1.5em;
@@ -478,6 +479,12 @@ $article-toolbar-width: 80px;
         border: 0;
       }
 
+    }
+
+    // headings within the article body
+    h2 {
+      border-top: 1px solid $mid-grey;
+      padding-top: 1em;
     }
 
     p, li, blockquote {

--- a/eruditorg/templates/base.html
+++ b/eruditorg/templates/base.html
@@ -13,9 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock title %} – Érudit</title>
-    {% block meta_description %}
-    <meta name="description" content="{% blocktrans %}Découvrez nos collections de documents en sciences humaines et sociales : revues, livres et actes, thèses, rapports de recherche.{% endblocktrans %}">
-    {% endblock meta_description %}
+    <meta name="description" content="{% block meta_description %}{% blocktrans %}Découvrez nos collections de documents en sciences humaines et sociales : revues, livres et actes, thèses, rapports de recherche.{% endblocktrans %}{% endblock meta_description %}">
 
     <!-- Android -->
     <meta name="theme-color" content="#222" />

--- a/eruditorg/templates/public/citations/list.html
+++ b/eruditorg/templates/public/citations/list.html
@@ -3,6 +3,9 @@
 
 {% block title %}{% trans "Ma bibliothèque" %}{% endblock title %}
 
+{% block meta_description %}{% trans 'Sauvegardez et téléchargez des notices d’articles en sciences humaines et sociales pour EndNote, Zotero, RefWorks, BibTeX et Mendeley sur la plateforme Érudit.' %}{% endblock meta_description %}
+
+
 {% block body_id %}citations_list{% endblock body_id %}
 {% block data_controller %}public:citations:list{% endblock data_controller %}
 

--- a/eruditorg/templates/public/journal/article_base.html
+++ b/eruditorg/templates/public/journal/article_base.html
@@ -1,0 +1,172 @@
+{% extends "public/base.html" %}
+{% load i18n staticfiles %}
+{% load public_journal_tags %}
+{% load cache %}
+
+{% block title %}{{ article.title|truncatechars:50 }} – {{ article.issue.journal.name|safe }}{% endblock title %}
+
+{% block meta_description %}{% blocktrans with journal_type=article.issue.journal.type|lower journal=article.issue.journal.name|safe article=article.title %}{{ article }}. Un article de la revue {{ journal_type }} {{ journal }}, diffusée par la plateforme Érudit. {% endblocktrans %}{% endblock meta_description %}
+
+{% block meta_tags %}
+{% cache FOREVER_TTL "public_article_detail_metatags" article.id LANGUAGE_CODE %}
+<!-- Facebook / Open Graph -->
+<meta property="fb:app_id" content="128099979787">
+<meta property="og:url" content="{{ request.build_absolute_uri }}">
+<meta property="og:type" content="article">
+<meta property="og:title" content="{{ article.title }}">
+<meta property="og:site_name" content="Érudit">
+<meta property="og:locale" content="fr_CA">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@eruditorg">
+<meta name="twitter:url" content="{{ request.build_absolute_uri }}">
+<meta name="twitter:title" content="{{ article.title }} – Érudit">
+
+<!-- Google Scholar -->
+<meta name="citation_title" content="{% for title in article.titles.all %}{{ title }}{% if not forloop.last %} / {% endif %}{% endfor %}" />
+<meta name="citation_journal_abbrev" content="{{ article.issue.journal.code }}">
+<meta name="citation_online_date" content="{{ article.issue.date_published|date:'Y/m/d' }}">
+<meta name="citation_abstract_html_url" content="http://id.erudit.org/iderudit/{{ article.localidentifier }}" />
+{% for author in article.erudit_object.authors %}
+{% if author.firstname and author.lastname %}
+<meta name="citation_author" content="{{ author.lastname }}, {{ author.firstname }}" />
+{% elif author.othername %}
+<meta name="citation_author" content="{{ author.othername }}" />
+{% endif %}
+{% if author.email %}
+<meta name="citation_author_email" content="{{ author.email }}" />
+{% endif %}
+{% for aff in author.affiliations %}
+<meta name="citation_author_institution" content="{{ aff }}" />
+{% endfor %}
+{% endfor %}
+<meta name="citation_journal_title" content="{{ article.issue.journal.name|safe }}{% if article.issue.journal.subtitle %}&nbsp;: {{ article.issue.journal.subtitle }}{% endif %}" />
+{% for abstract in article.abstracts.all %}
+<meta name="citation_abstract" lang="{{ abstract.language }}" content="{{ abstract.text }}" />
+{% endfor %}
+<meta name="citation_language" content="{{ article.language }}" />
+{% if article.first_page %}
+<meta name="citation_firstpage" content="{{ article.first_page }}" />
+{% endif %}
+{% if article.last_page %}
+<meta name="citation_lastpage" content="{{ article.last_page }}" />
+{% endif %}
+{% if article.issue.journal.issn_print %}
+<meta name="citation_issn" content="{{ article.issue.journal.issn_print }}" />
+{% endif %}
+{% if article.issue.journal.issn_web %}
+<meta name="citation_issn" content="{{ article.issue.journal.issn_web }}" />
+{% endif %}
+{% if article.issue.volume %}
+<meta name="citation_volume" content="{{ article.issue.volume }}" />
+{% endif %}
+{% if article.issue.number %}
+<meta name="citation_issue" content="{{ article.issue.number }}" />
+{% endif %}
+{% if not article.issue.embargoed %}
+<meta name="citation_fulltext_world_readable" content="" />
+{% endif %}
+<meta name="citation_publication_date" content="{{ article.issue.year }}" />
+<meta name="citation_date" content="{{ article.issue.year }}" />
+<meta name="citation_publisher" content="{{ article.publisher.name }}" />
+{% if article.doi %}<meta name="citation_doi" content="{{ article.doi }}" />{% endif %}
+{% if article.erudit_object.processing == 'complet' %}
+<meta name="citation_html_url" content="{{ request.is_secure|yesno:"https,http" }}://{{ request.site.domain }}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" />
+{% endif %}
+{% if article.fedora_object.pdf.exists %}
+<meta name="citation_pdf_url" content="{{ request.is_secure|yesno:"https,http" }}://{{ request.site.domain }}{% url 'public:journal:article_raw_pdf' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" />
+{% endif %}
+{% for keywords_lang in article.erudit_object.keywords %}
+  <meta name="citation_keywords" lang="{{ keywords_lang.lang }}" content="{% for k in keywords_lang.keywords %}{{ k }}{% if not forloop.last %}, {% endif %}{% endfor %}" />
+{% endfor %}
+{% endcache %}
+{% endblock meta_tags %}
+
+{% block structured_data %}
+{{ block.super }}
+{% cache FOREVER_TTL "public_article_detail_structured_data" article.id LANGUAGE_CODE %}
+{% include "public/journal/partials/article_structured_data.html" %}
+{% endcache %}
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [{
+    "@type": "ListItem",
+    "position": 1,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}",
+      "name": "Érudit"
+    }
+  },{
+    "@type": "ListItem",
+    "position": 2,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:journal_list' %}",
+      "name": "{% trans 'Revues' %}"
+    }
+  },{
+    "@type": "ListItem",
+    "position": 3,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:journal_detail' article.issue.journal.code %}",
+      "name": "{{ article.issue.journal.name }}"
+    }
+  },{
+    "@type": "ListItem",
+    "position": 4,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}",
+      "name": "{{ article.issue.volume_title_with_pages }}"
+    }
+  },{
+    "@type": "ListItem",
+    "position": 5,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:article_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}",
+      "name": "{{ article.title }}"
+    }
+  }]
+}
+</script>
+{% endblock structured_data %}
+
+{% block body_class %}public static-header{% endblock body_class %}
+{% block body_id %}article_detail{% endblock body_id %}
+{% block data_controller %}public:journal:article_detail{% endblock data_controller %}
+
+{% block header_class %}static{% endblock header_class %}
+
+{% block breadcrumb %}
+{{ block.super }}
+<li>
+  <a href="{% url 'public:journal:journal_detail' article.issue.journal.code %}">{{ article.issue.journal.name }}</a>
+</li>
+<li>
+  <a href="{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}">
+   {% if article.issue.html_title %}
+   {{ article.issue.html_title|striptags|safe|truncatechars:50 }}
+   {% else %}
+   {{ article.issue.volume_title_with_pages }}
+   {% endif %}
+  </a>
+</li>
+<li>
+  <a href="{% url 'public:journal:article_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">{{ article.title|truncatechars:50 }}</a>
+</li>
+{% endblock breadcrumb %}
+
+{% block alert %}
+<div class="alert alert-warning">
+  <div class="container">
+    <p>
+      {% blocktrans %}
+      <span class="ion-alert-circled"></span> <strong>Attention</strong>&nbsp;: le site que vous visitez est actuellement en version bêta. L’affichage des articles (HTML, PDF) sera amélioré au cours des prochaines semaines. <br/><strong>Veuillez ne pas citer cet article</strong>, car l’adresse URL de cette page est temporaire. Pour citer un article, veuillez vous référer à <a href="{{ fallback_url }}" target="_blank">www.erudit.org</a>.
+      {% endblocktrans %}
+    </p>
+  </div>
+</div>
+{% endblock alert %}
+
+{% block content %}{% endblock content %}

--- a/eruditorg/templates/public/journal/article_detail.html
+++ b/eruditorg/templates/public/journal/article_detail.html
@@ -1,89 +1,7 @@
-{% extends "public/base.html" %}
+{% extends "public/journal/article_base.html" %}
 {% load i18n staticfiles %}
 {% load public_journal_tags %}
 {% load cache %}
-
-{% block title %}{{ article.title }} – {{ article.issue.journal.name }}{% if article.issue.journal.subtitle %} : {{ article.issue.journal.subtitle }}{% endif %}{% endblock title %}
-
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Un article {{ article.journal_type }} de la revue {{ article.issue.journal.name }}, diffusée par plateforme Érudit. {% endblocktrans %}">
-{% endblock meta_description %}
-
-{% block meta_tags %}
-{% cache FOREVER_TTL "public_article_detail_metatags" article.id LANGUAGE_CODE %}
-<!-- Facebook / Open Graph -->
-<meta property="fb:app_id" content="128099979787">
-<meta property="og:url" content="{{ request.build_absolute_uri }}">
-<meta property="og:type" content="article">
-<meta property="og:title" content="{{ article.title }}">
-<meta property="og:site_name" content="Érudit">
-<meta property="og:locale" content="fr_CA">
-
-<!-- Twitter -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@eruditorg">
-<meta name="twitter:url" content="{{ request.build_absolute_uri }}">
-<meta name="twitter:title" content="{{ article.title }} – Érudit">
-
-<!-- Google Scholar -->
-<meta name="citation_title" content="{% for title in article.titles.all %}{{ title }}{% if not forloop.last %} / {% endif %}{% endfor %}" />
-<meta name="citation_journal_abbrev" content="{{ article.issue.journal.code }}">
-<meta name="citation_online_date" content="{{ article.issue.date_published|date:'Y/m/d' }}">
-<meta name="citation_abstract_html_url" content="http://id.erudit.org/iderudit/{{ article.localidentifier }}" />
-{% for author in article.erudit_object.authors %}
-{% if author.firstname and author.lastname %}
-<meta name="citation_author" content="{{ author.lastname }}, {{ author.firstname }}" />
-{% elif author.othername %}
-<meta name="citation_author" content="{{ author.othername }}" />
-{% endif %}
-{% if author.email %}
-<meta name="citation_author_email" content="{{ author.email }}" />
-{% endif %}
-{% for aff in author.affiliations %}
-<meta name="citation_author_institution" content="{{ aff }}" />
-{% endfor %}
-{% endfor %}
-<meta name="citation_journal_title" content="{{ article.issue.journal.name }}{% if article.issue.journal.subtitle %}&nbsp;: {{ article.issue.journal.subtitle }}{% endif %}" />
-{% for abstract in article.abstracts.all %}
-<meta name="citation_abstract" lang="{{ abstract.language }}" content="{{ abstract.text }}" />
-{% endfor %}
-<meta name="citation_language" content="{{ article.language }}" />
-{% if article.first_page %}
-<meta name="citation_firstpage" content="{{ article.first_page }}" />
-{% endif %}
-{% if article.last_page %}
-<meta name="citation_lastpage" content="{{ article.last_page }}" />
-{% endif %}
-{% if article.issue.journal.issn_print %}
-<meta name="citation_issn" content="{{ article.issue.journal.issn_print }}" />
-{% endif %}
-{% if article.issue.journal.issn_web %}
-<meta name="citation_issn" content="{{ article.issue.journal.issn_web }}" />
-{% endif %}
-{% if article.issue.volume %}
-<meta name="citation_volume" content="{{ article.issue.volume }}" />
-{% endif %}
-{% if article.issue.number %}
-<meta name="citation_issue" content="{{ article.issue.number }}" />
-{% endif %}
-{% if not article.issue.embargoed %}
-<meta name="citation_fulltext_world_readable" content="" />
-{% endif %}
-<meta name="citation_publication_date" content="{{ article.issue.year }}" />
-<meta name="citation_date" content="{{ article.issue.year }}" />
-<meta name="citation_publisher" content="{{ article.publisher.name }}" />
-{% if article.doi %}<meta name="citation_doi" content="{{ article.doi }}" />{% endif %}
-{% if article.erudit_object.processing == 'complet' %}
-<meta name="citation_html_url" content="{{ request.is_secure|yesno:"https,http" }}://{{ request.site.domain }}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" />
-{% endif %}
-{% if article.fedora_object.pdf.exists %}
-<meta name="citation_pdf_url" content="{{ request.is_secure|yesno:"https,http" }}://{{ request.site.domain }}{% url 'public:journal:article_raw_pdf' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" />
-{% endif %}
-{% for keywords_lang in article.erudit_object.keywords %}
-  <meta name="citation_keywords" lang="{{ keywords_lang.lang }}" content="{% for k in keywords_lang.keywords %}{{ k }}{% if not forloop.last %}, {% endif %}{% endfor %}" />
-{% endfor %}
-{% endcache %}
-{% endblock meta_tags %}
 
 {% block structured_data %}
 {{ block.super }}
@@ -133,30 +51,6 @@
 }
 </script>
 {% endblock structured_data %}
-
-{% block body_class %}public static-header{% endblock body_class %}
-{% block body_id %}article_detail{% endblock body_id %}
-{% block data_controller %}public:journal:article_detail{% endblock data_controller %}
-
-{% block header_class %}static{% endblock header_class %}
-
-{% block breadcrumb %}{{ block.super }}
-<li>
-  <a href="{% url 'public:journal:journal_detail' article.issue.journal.code %}">{{ article.issue.journal.name }}</a>
-</li>
-<li>
-  <a href="{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}">
-   {% if article.issue.html_title %}
-   {{ article.issue.html_title|striptags|safe|truncatechars:50 }}
-   {% else %}
-   {{ article.issue.volume_title_with_pages }}
-   {% endif %}
-  </a>
-</li>
-<li>
-  <a href="{% url 'public:journal:article_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">{{ article.title|truncatechars:50 }}</a>
-</li>
-{% endblock breadcrumb %}
 
 {% block alert %}
 <div class="alert alert-warning">

--- a/eruditorg/templates/public/journal/article_summary.html
+++ b/eruditorg/templates/public/journal/article_summary.html
@@ -1,79 +1,11 @@
-{% extends "public/base.html" %}
+{% extends "public/journal/article_base.html" %}
 {% load i18n staticfiles %}
 {% load public_journal_tags %}
 {% load cache %}
 
-{% block title %}{{ article.title }} {% trans '(notice)' %} – {{ article.issue.journal.name }}{% if article.issue.journal.subtitle %} : {{ article.issue.journal.subtitle }}{% endif %}{% endblock title %}
-
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Notice. Un article {{ article.journal_type }} de la revue {{ article.issue.journal.name }}, diffusée par la plateforme Érudit. {% endblocktrans %}">
-{% endblock meta_description %}
-
-{% block data_controller %}public:journal:article_detail{% endblock data_controller %}
-
-{% block meta_tags %}
-{% cache FOREVER_TTL "public_article_summary_metatags" article.id LANGUAGE_CODE %}
-<!-- Facebook / Open Graph -->
-<meta property="fb:app_id" content="128099979787">
-<meta property="og:url" content="{{ request.build_absolute_uri }}">
-<meta property="og:type" content="article">
-<meta property="og:title" content="{{ article.title }}">
-<meta property="og:site_name" content="Érudit">
-<meta property="og:locale" content="fr_CA">
-
-<!-- Twitter -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@eruditorg">
-<meta name="twitter:url" content="{{ request.build_absolute_uri }}">
-<meta name="twitter:title" content="{{ article.title }} – Érudit">
-
-<!-- Google Scholar -->
-<meta name="citation_title" content="{{ article.title }}" />
-{% for author in article.authors.all %}
-  {% if author.firstname and author.lastname %}
-    <meta name="citation_author" content="{{ author.lastname }}, {{ author.firstname }}" />
-  {% elif author.othername %}
-    <meta name="citation_author" content="{{ author.othername }}" />
-  {% endif %}
-  {% for aff in author.affiliations.all %}
-    <meta name="citation_author_institution" content="{{ aff.name }}" />
-  {% endfor %}
-{% endfor %}
-<meta name="citation_journal_title" content="{{ article.issue.journal.name }}" />
-{% for abstract in article.abstracts.all %}
-  <meta name="citation_abstract" lang="{{ abstract.language }}" content="{{ abstract.text }}" />
-{% endfor %}
-<meta name="citation_language" content="{{ article.language }}" />
-{% if article.first_page %}
-  <meta name="citation_firstpage" content="{{ article.first_page }}" />
-{% endif %}
-{% if article.last_page %}
-  <meta name="citation_lastpage" content="{{ article.last_page }}" />
-{% endif %}
-<meta name="citation_issn" content="{{ article.issue.journal.issn_print|default:article.issue.journal.issn_web }}" />
-{% if article.issue.volume %}
-  <meta name="citation_volume" content="{{ article.issue.volume }}" />
-{% endif %}
-{% if article.issue.number %}
-  <meta name="citation_issue" content="{{ article.issue.number }}" />
-{% endif %}
-{% if not article.issue.embargoed %}
-<meta name="citation_fulltext_world_readable" content="" />
-{% endif %}
-<meta name="citation_publication_date" content="{{ article.issue.year }}" />
-<meta name="citation_date" content="{{ article.issue.year }}" />
-<meta name="citation_publisher" content="{{ article.publisher.name }}" />
-{% if article.doi %}<meta name="citation_doi" content="{{ article.doi }}" />{% endif %}
-<meta name="citation_html_url" content="{{ request.is_secure|yesno:"https,http" }}://{{ request.site.domain }}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" />
-<meta name="citation_pdf_url" content="{{ request.is_secure|yesno:"https,http" }}://{{ request.site.domain }}{% url 'public:journal:article_raw_pdf' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" />
-{% for lang_code, keywords in keywords_dict.items %}
-  <meta name="citation_keywords" lang="{{ lang_code }}" content="{% for k in keywords %}{{ k.name }}{% if not forloop.last %}, {% endif %}{% endfor %}" />
-{% endfor %}
-{% endcache %}
-{% endblock meta_tags %}
+{% block meta_description %}{% trans 'Notice. ' %}{{ block.super }}{% endblock meta_description %}
 
 {% block structured_data %}
-{{ block.super }}
 {% cache FOREVER_TTL "public_article_summary_structured_data" article.id LANGUAGE_CODE %}
 {% include "public/journal/partials/article_structured_data.html" %}
 {% endcache %}
@@ -104,36 +36,34 @@
     }
   },{
     "@type": "ListItem",
+    "position": 4,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}",
+      "name": "{{ article.issue.volume_title_with_pages }}"
+    }
+  },{
+    "@type": "ListItem",
     "position": 5,
     "item": {
-      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:article_summary' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}",
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:article_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}",
       "name": "{{ article.title }}"
+    }
+  },{
+    "@type": "ListItem",
+    "position": 6,
+    "item": {
+      "@id": "{{ request.scheme }}://{{ request.site.domain }}{% url 'public:journal:article_summary' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}",
+      "name": "{% trans 'Notice bibliographique' %}"
     }
   }]
 }
 </script>
 {% endblock structured_data %}
 
-{% block body_class %}public static-header{% endblock body_class %}
-{% block body_id %}article_detail{% endblock body_id %}
-
-{% block header_class %}static{% endblock header_class %}
-
-{% block breadcrumb %}{{ block.super }}
+{% block breadcrumb %}
+{{ block.super }}
 <li>
-  <a href="{% url 'public:journal:journal_detail' article.issue.journal.code %}">{{ article.issue.journal.name }}</a>
-</li>
-<li>
-  <a href="{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}">
-   {% if article.issue.html_title %}
-   {{ article.issue.html_title|safe|truncatechars:50 }}
-   {% else %}
-   {{ article.issue.volume_title_with_pages }}
-   {% endif %}
-  </a>
-</li>
-<li>
-  <a href="{% url 'public:journal:article_summary' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">{% blocktrans with title=article.title|truncatechars:50 %}{{ title }} - Résumé{% endblocktrans %}</a>
+  <a href="{% url 'public:journal:article_summary' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">{% trans 'Notice bibliographique' %}</a>
 </li>
 {% endblock breadcrumb %}
 

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -54,6 +54,9 @@
       <hgroup class="col-xs-12 child-column-fit">
 
         <div class="col-sm-9">
+          {% if only_summary %}
+          <p class="title-summary">{% trans 'Notice' %}</p>
+          {% endif %}
           <xsl:if test="liminaire/grtitre/surtitre">
             <p class="title-tag">
               <xsl:apply-templates select="liminaire/grtitre/surtitre" mode="title"/>
@@ -66,9 +69,6 @@
             <xsl:apply-templates select="liminaire/grtitre/titreparal" mode="title"/>
             <xsl:apply-templates select="liminaire/grtitre/sstitreparal" mode="title"/>
             <xsl:apply-templates select="liminaire/grtitre/trefbiblio" mode="title"/>
-            {% if only_summary %}
-            <span>{% trans 'Notice' %}</span>
-            {% endif %}
           </h1>
 
           <xsl:if test="liminaire/grauteur">
@@ -77,14 +77,13 @@
             </ul>
           </xsl:if>
 
-          {% if only_summary %}
-          <a href="{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" class="btn btn-primary">{% trans "Lire le texte intégral" %} <span class="ion ion-arrow-right-c"></span></a>
-          {% endif %}
-
         </div>
 
         <!-- TODO: cover image -->
         <div class="issue-cover col-sm-3">
+          {% if only_summary %}
+          <a href="{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" class="btn btn-primary">{% trans "Lire le texte intégral" %} <span class="ion ion-arrow-right-c"></span></a>
+          {% endif %}
         </div>
       </hgroup>
 
@@ -168,6 +167,7 @@
             </xsl:if>
             {% endif %}
             <xsl:for-each select="partiesann[1]">
+              {% if article_access_granted and not only_summary %}
               <xsl:if test="grannexe">
                 <li>
                   <a href="#grannexe">
@@ -189,13 +189,6 @@
                   </a>
                 </li>
               </xsl:if>
-              <xsl:if test="grbiblio">
-                <li>
-                  <a href="#grbiblio">
-                    <xsl:apply-templates select="grbiblio" mode="toc-heading"/>
-                  </a>
-                </li>
-              </xsl:if>
               <xsl:if test="grnote">
                 <li>
                   <a href="#grnote">
@@ -203,7 +196,16 @@
                   </a>
                 </li>
               </xsl:if>
+              {% endif %}
+              <xsl:if test="grbiblio">
+                <li>
+                  <a href="#grbiblio">
+                    <xsl:apply-templates select="grbiblio" mode="toc-heading"/>
+                  </a>
+                </li>
+              </xsl:if>
             </xsl:for-each>
+            {% if not only_summary %}
             <xsl:if test="//figure">
               <li>
                 <a href="#figures">{% trans "Liste des figures" %}</a>
@@ -214,6 +216,7 @@
                 <a href="#tableaux">{% trans "Liste des tableaux" %}</a>
               </li>
             </xsl:if>
+            {% endif %}
           </ul>
         </nav>
         {% endif %}
@@ -307,6 +310,7 @@
         <xsl:apply-templates select="partiesann[node()]"/>
 
         <!-- lists of tables & figures -->
+        {% if not only_summary %}
         <xsl:if test="//figure">
           <section id="figures" class="article-section figures" role="complementary">
             <h2>{% trans "Liste des figures" %}</h2>
@@ -320,6 +324,7 @@
             <xsl:apply-templates select="//tableau/objetmedia" mode="liste"/>
           </section>
         </xsl:if>
+        {% endif %}
 
       </div>
     </div>
@@ -1766,15 +1771,14 @@
 
   <!--*** APPPENDIX ***-->
   <xsl:template match="partiesann">
-    <!-- <section id="partiesann"> -->
     <xsl:apply-templates/>
-    <!-- </section> -->
   </xsl:template>
 
   <xsl:template match="grannexe | merci | grnotebio | grnote | grbiblio">
     <section id="{name()}" class="article-section {name()}" role="complementary">
       <h2>
         <xsl:choose>
+          {% if not only_summary %}
           <xsl:when test="self::grannexe">
             <xsl:apply-templates select="self::grannexe" mode="toc-heading"/>
           </xsl:when>
@@ -1787,13 +1791,20 @@
           <xsl:when test="self::grnote">
             <xsl:apply-templates select="self::grnote" mode="toc-heading"/>
           </xsl:when>
+          {% endif %}
           <xsl:when test="self::grbiblio">
             <xsl:apply-templates select="self::grbiblio" mode="toc-heading"/>
           </xsl:when>
         </xsl:choose>
       </h2>
       <xsl:choose>
-        <xsl:when test="self::grnote | self::grbiblio">
+        <xsl:when test="self::grbiblio">
+          <ol class="unstyled">
+            <xsl:apply-templates select="*[not(self::titre)]"/>
+          </ol>
+        </xsl:when>
+        {% if not only_summary %}
+        <xsl:when test="self::grnote">
           <ol class="unstyled">
             <xsl:apply-templates select="*[not(self::titre)]"/>
           </ol>
@@ -1801,6 +1812,7 @@
         <xsl:otherwise>
           <xsl:apply-templates select="*[not(self::titre)]"/>
         </xsl:otherwise>
+        {% endif %}
       </xsl:choose>
     </section>
   </xsl:template>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -337,7 +337,7 @@
   <!-- identifiers -->
   <xsl:template match="idpublic[@scheme = 'doi']">
     <xsl:text>&#x0020;</xsl:text>
-    <a href="{$doiStart}{.}">
+    <a href="{$doiStart}{.}" class="refbiblio-link {name()}" target="_blank">
       <xsl:if test="contains( . , '10.7202')">
         <img src="{% static 'svg/symbole-erudit.svg' %}" title="DOI Érudit" alt="Icône pour les DOIs Érudit" class="erudit-doi"/>
       </xsl:if>
@@ -347,7 +347,7 @@
   </xsl:template>
 
   <xsl:template match="idpublic[@scheme='uri']">
-    <a href="{$uriStart}{.}">
+    <a href="{$uriStart}{.}" class="refbiblio-link {name()}" target="_blank">
       <xsl:text>URI:</xsl:text>
       <xsl:value-of select="."/>
     </a>
@@ -1955,19 +1955,31 @@
   </xsl:template>
   <xsl:template match="refbiblio">
     <xsl:variable name="valeurNO" select="no"/>
-    <li class="refbiblio" role="note">
-      <a class="no" id="{@id}">
-        <xsl:choose>
-          <xsl:when test="$valeurNO">
-            <xsl:apply-templates select="$valeurNO"/>
-            <xsl:text>.</xsl:text>
-          </xsl:when>
-          <xsl:otherwise></xsl:otherwise>
-        </xsl:choose>
-      </a>
+    <li class="refbiblio"  id="{@id}" role="note">
+      <xsl:choose>
+        <xsl:when test="$valeurNO">
+          <xsl:apply-templates select="$valeurNO"/>
+          <xsl:text>. </xsl:text>
+        </xsl:when>
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="node()[name() != 'idpublic' and name() != 'no']"/>
-      <xsl:text></xsl:text>
-      <xsl:apply-templates select="idpublic"/>
+      <div class="refbiblio-links">
+        <xsl:element name="a">
+          <xsl:attribute name="href">
+            <xsl:text>http://scholar.google.com/scholar?q=</xsl:text>
+            <xsl:apply-templates select="node()[name() != 'idpublic' and name() != 'no']"/>
+          </xsl:attribute>
+          <xsl:attribute name="class">
+            <xsl:text>refbiblio-link scholar-link</xsl:text>
+          </xsl:attribute>
+          <xsl:attribute name="target">
+            <xsl:text>_blank</xsl:text>
+          </xsl:attribute>
+          <xsl:text>Google Scholar</xsl:text>
+        </xsl:element>
+        <xsl:apply-templates select="idpublic"/>
+      </div>
     </li>
   </xsl:template>
 

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -3,11 +3,9 @@
 {% load staticfiles %}
 {% load cache %}
 
-{% block title %}{% if issue.html_title %}{{ issue.html_title|safe }}. {% endif %}{{ issue.volume_title }} – {{ issue.journal.name }}{% endblock title %}
+{% block title %}{% if issue.html_title %}{{ issue.html_title|safe }}. {% endif %}{{ issue.volume_title }} – {{ issue.journal.name|safe }}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Consultez le sommaire de ce numéro de la revue {{ issue.journal.name }} sur la plateforme Érudit.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans with journal_type=issue.journal.type|lower journal=issue.journal.name|safe %}Consultez le sommaire de ce numéro de la revue {{ journal_type }} {{ journal }} sur la plateforme Érudit.{% endblocktrans %} {% trans 'Discipline : ' %}{% for discipline in issue.journal.disciplines.all %}{{ discipline.name }}{% if not forloop.last %}, {% endif %}{% endfor %}.{% endblock meta_description %}
 
 {% block meta_tags %}
 <!-- Facebook / Open Graph -->

--- a/eruditorg/templates/public/journal/journal_authors_list.html
+++ b/eruditorg/templates/public/journal/journal_authors_list.html
@@ -3,11 +3,9 @@
 {% load cache %}
 {% load public_journal_tags %}
 
-{% block title %}{% trans "Index des auteurs" %} – {{ journal.name }}{% endblock title %}
+{% block title %}{% trans "Index des auteurs" %} – {{ journal.name|safe }}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Explorez la liste des auteurs par ordre alphabétique et par type de publication de la revue {{ journal.name }}.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans with type=journal.type|lower journal=journal.name|safe %}Explorez la liste des auteurs par ordre alphabétique et par type de publication de la revue {{ type }} {{ journal }} sur la plateforme Érudit.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data %}
 {{ block.super }}

--- a/eruditorg/templates/public/journal/journal_detail.html
+++ b/eruditorg/templates/public/journal/journal_detail.html
@@ -1,11 +1,9 @@
 {% extends "public/journal/journal_base.html" %}
 {% load i18n staticfiles cache %}
 
-{% block title %}{{ journal.name }}{% if article.issue.journal.subtitle %} : {{ article.issue.journal.subtitle }}{% endif %}{% endblock title %}
+{% block title %}{{ journal.name|safe }}{% if article.issue.journal.subtitle %} : {{ article.issue.journal.subtitle }}{% endif %}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}{{ journal_info.about|striptags|truncatechars:150 }}{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans with journal_about=journal_info.about|safe|striptags|truncatechars:175 %}{{ journal_about }}{% endblocktrans %}{% endblock meta_description %}
 
 {% block meta_tags %}
 <!-- Facebook / Open Graph -->

--- a/eruditorg/templates/public/journal/journal_list_per_disciplines.html
+++ b/eruditorg/templates/public/journal/journal_list_per_disciplines.html
@@ -5,9 +5,7 @@
 
 {% block title %}{% trans "Revues par disciplines" %}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Découvrez la liste par discipline des revues savantes et culturelles d'Érudit et de ses partenaires.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans %}Découvrez la liste par discipline en sciences humaines et sociales des revues savantes et culturelles d'Érudit et de ses partenaires.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data %}
 {{ block.super }}

--- a/eruditorg/templates/public/journal/journal_list_per_names.html
+++ b/eruditorg/templates/public/journal/journal_list_per_names.html
@@ -6,9 +6,7 @@
 
 {% block title %}{% trans "Revues par ordre alphabétique" %}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Découvrez la liste par ordre alphabétique des revues savantes et culturelles d'Érudit et de ses partenaires.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans %}Découvrez la liste alphabétique des revues savantes et culturelles en sciences humaines et sociales d'Érudit et de ses partenaires.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data %}
 {{ block.super }}

--- a/eruditorg/templates/public/search/advanced_search.html
+++ b/eruditorg/templates/public/search/advanced_search.html
@@ -4,9 +4,7 @@
 
 {% block title %}{% trans "Recherche avancée" %}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Effectuez une recherche avancée dans le corpus Érudit à l'aide d'opérateurs booléens et de filtres.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans %}Effectuez une recherche avancée dans le corpus Érudit à l'aide d'opérateurs booléens et de filtres.{% endblocktrans %}{% endblock meta_description %}
 
 {% block body_class %}{{ block.super }} advanced_search{% endblock body_class %}
 

--- a/eruditorg/templates/public/thesis/collection_home.html
+++ b/eruditorg/templates/public/thesis/collection_home.html
@@ -1,11 +1,9 @@
 {% extends "public/base.html" %}
 {% load i18n %}
 
-{% block title %}{% blocktrans %}Thèses de {{ collection.name }}{% endblocktrans %}{% endblock title %}
+{% block title %}{% blocktrans with collection=collection.name %}Thèses de {{ collection }}{% endblocktrans %}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Accédez aux thèses et mémoires du dépôt institutionnel de {{ collection.name }}.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans with collection=collection.name %}Accédez aux thèses et mémoires du dépôt institutionnel de {{ collection }} sur la plateforme Érudit.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data %}
 {{ block.super }}

--- a/eruditorg/templates/public/thesis/collection_list_per_author_name.html
+++ b/eruditorg/templates/public/thesis/collection_list_per_author_name.html
@@ -1,11 +1,9 @@
 {% extends "public/thesis/collection_list_base.html" %}
 {% load i18n %}
 
-{% block title %}{% blocktrans with letter=author_letter %}Auteurs commençant par {{ letter }}{% endblocktrans %} &ndash; Thèses de {{ collection.name }}{% endblock title %}
+{% block title %}{% blocktrans with letter=author_letter collection=collection.name %}Auteurs commençant par {{ letter }}{% endblocktrans %} – Thèses de {{ collection }}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans with letter=author_letter %}Consultez les thèses et mémoires de {{ collection.name }} par auteur commençant par {{ letter }} sur la plateforme Érudit.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans with letter=author_letter %}Consultez les thèses et mémoires de {{ collection }} par auteur commençant par {{ letter }} sur la plateforme Érudit.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data_breadcrumb_tail %}
 {

--- a/eruditorg/templates/public/thesis/collection_list_per_year.html
+++ b/eruditorg/templates/public/thesis/collection_list_per_year.html
@@ -1,11 +1,9 @@
 {% extends "public/thesis/collection_list_base.html" %}
 {% load i18n %}
 
-{% block title %}{% blocktrans with year=publication_year %}Thèses publiées en {{ year }}{% endblocktrans %}&nbsp;&ndash;&nbsp;{{ collection.name }}{% endblock title %}
+{% block title %}{% blocktrans with year=publication_year collection=collection.name %}Thèses publiées en {{ year }}{% endblocktrans %} – {{ collection }}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans with year=publication_year %}Consultez les thèses et mémoires de {{ collection.name }} publiées en {{ year }} sur la plateforme Érudit.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans with year=publication_year collection=collection.name %}Consultez les thèses et mémoires de {{ collection }} publiées en {{ year }} sur la plateforme Érudit.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data_breadcrumb_tail %}
 {

--- a/eruditorg/templates/public/thesis/home.html
+++ b/eruditorg/templates/public/thesis/home.html
@@ -3,9 +3,7 @@
 
 {% block title %}{% trans "Thèses" %}{% endblock title %}
 
-{% block meta_description %}
-<meta name="description" content="{% blocktrans %}Consultez les dépôts de thèses et mémoires de plusieurs universités canadiennes.{% endblocktrans %}">
-{% endblock meta_description %}
+{% block meta_description %}{% blocktrans %}Consultez les dépôts de thèses et mémoires de plusieurs universités canadiennes sur la plateforme Érudit.{% endblocktrans %}{% endblock meta_description %}
 
 {% block structured_data %}
 {{ block.super }}


### PR DESCRIPTION
- Abstract / bibliographic notice page examples
  - [Without an abstract but with bibliography](http://localhost:8000/fr/revues/ms/2006-v22-n10-ms1424/013801ar/resume/)
  - [With abstracts and bibliography](http://localhost:8000/fr/revues/meta/2013-v58-n3-meta01406/1025047ar/resume/)
- Scholar Lookup Links examples 
  - [Excluding `<no>` in query](http://localhost:8000/fr/revues/ms/2006-v22-n10-ms1424/013801ar/#grbiblio)
  - [Followed by DOIs (both Érudit & non-Érudit)](http://localhost:8000/fr/revues/meta/2013-v58-n3-meta01406/1025047ar#grbiblio)
- SEO copy examples (check `<title>` and `<meta name="description">` elements)
  - [Homepage](http://localhost:8000/fr/)
  - [Theses](http://localhost:8000/fr/these/)
  - [Thesis collection home](http://localhost:8000/fr/these/fonds/6/)
  - Cultural journal
    - [Detail](http://localhost:8000/fr/revues/images/)
    - [Index author](http://localhost:8000/fr/revues/images/auteurs/)
    - [Issue](http://localhost:8000/fr/revues/images/2012-n160-images0407/)
    - [Bibliographic record](http://localhost:8000/fr/revues/images/2012-n160-images0407/68293ac/resume/)
  - Scientific journal
    - [Detail](http://localhost:8000/fr/revues/ae/)
    - [Issue](http://localhost:8000/fr/revues/ae/2014-v90-n3-ae02325/)
    - [Article](http://localhost:8000/fr/revues/ae/2014-v90-n3-ae02325/1034737ar/)