### PR TITLE
Display cover image or journal logo in article header

### DIFF
--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -174,10 +174,18 @@ $article-toolbar-width: 80px;
       margin: 0.35em 0;
     }
 
-    .issue-cover {
+    .issue-image {
+
       img {
+        margin-bottom: 1em;
         float: right;
       }
+
+      .issue-cover {
+        max-height: 150px;
+        outline: 1px solid $mid-grey;
+      }
+
     }
 
     .meta-article {
@@ -249,6 +257,7 @@ $article-toolbar-width: 80px;
 
       .pagination {
         margin: 0;
+        padding: 0;
         display: inline;
       }
 

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -70,17 +70,25 @@
             <xsl:apply-templates select="liminaire/grtitre/sstitreparal" mode="title"/>
             <xsl:apply-templates select="liminaire/grtitre/trefbiblio" mode="title"/>
           </h1>
-
           <xsl:if test="liminaire/grauteur">
             <ul class="grauteur">
               <xsl:apply-templates select="liminaire/grauteur/auteur" mode="author"/>
             </ul>
           </xsl:if>
-
         </div>
 
-        <!-- TODO: cover image -->
-        <div class="issue-cover col-sm-3">
+        <!-- issue cover image or journal logo -->
+        <div class="issue-image col-sm-3">
+          {% if article.issue.has_coverpage %}
+          <a href="{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}" title="{% blocktrans with journal=article.issue.journal.name %}Consulter ce numéro de la revue {{ journal }}{% endblocktrans %}">
+            <img src="{% url 'public:journal:issue_coverpage' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}" class="img-responsive issue-cover" alt="{% trans 'Couverture de' %} {% if article.issue.html_title %}{{ article.issue.html_title|safe }}, {% endif %}
+              {{ article.issue.volume_title_with_pages }}, {{ article.issue.journal.name }}" />
+            </a>
+          {% else %}
+          <a href="{% url 'public:journal:issue_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier %}" title="{% blocktrans with journal=article.issue.journal.name %}Consulter ce numéro de la revue {{ journal }}{% endblocktrans %}">
+            <img src="{% url 'public:journal:journal_logo' article.issue.journal.code %}" class="img-responsive journal-logo" alt="{% trans 'Logo de' %} {{ article.issue.journal.name }}" />
+          </a>
+          {% endif %}
           {% if only_summary %}
           <a href="{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}" class="btn btn-primary">{% trans "Lire le texte intégral" %} <span class="ion ion-arrow-right-c"></span></a>
           {% endif %}
@@ -103,7 +111,7 @@
               </a>
             </span>
           </dd>
-          {% if not article.issue.journal.type.code == 'C' %}
+          {% if article.issue.journal.type.code == 'S' %}
           <dt>DOI</dt>
           <dd>
             <span class="hint--top hint--no-animate" data-hint="{% blocktrans %}Cliquez pour copier le DOI de cet article.{% endblocktrans %}">

--- a/tests/unit/apps/public/journal/test_templatetags.py
+++ b/tests/unit/apps/public/journal/test_templatetags.py
@@ -10,21 +10,35 @@ from erudit.test import BaseEruditTestCase
 from erudit.test.factories import ArticleFactory
 from erudit.test.factories import IssueFactory
 from erudit.fedora.objects import ArticleDigitalObject
-
+from erudit.models import Issue
 from apps.public.journal.templatetags.public_journal_tags import render_article
 
 FIXTURE_ROOT = os.path.join(os.path.dirname(__file__), 'fixtures')
 
 
+@unittest.mock.patch.object(
+    ArticleDigitalObject,
+    'erudit_xsd300',
+    content=unittest.mock.MagicMock()
+)
+@unittest.mock.patch.object(
+    ArticleDigitalObject,
+    '_get_datastreams',
+    return_value=['ERUDITXSD300', ]
+)
+@unittest.mock.patch.object(
+    Issue,
+    'has_coverpage',
+    return_value=True
+)
 class TestRenderArticleTemplateTag(BaseEruditTestCase):
-    @unittest.mock.patch.object(ArticleDigitalObject, 'erudit_xsd300')
-    @unittest.mock.patch.object(ArticleDigitalObject, '_get_datastreams')
-    def test_can_transform_article_xml_to_html(self, mock_ds, mock_xsd300):
+
+    def test_can_transform_article_xml_to_html(
+        self, mock_has_coverpage, mock_ds, mock_xsd300
+    ):
         # Setup
         with open(FIXTURE_ROOT + '/article.xml', mode='r') as fp:
             xml = fp.read()
-        mock_ds.return_value = ['ERUDITXSD300', ]  # noqa
-        mock_xsd300.content = unittest.mock.MagicMock()
         mock_xsd300.content.serialize = unittest.mock.MagicMock(return_value=xml)
         issue = IssueFactory.create(
             journal=self.journal, date_published=dt.datetime.now(), localidentifier='test')
@@ -36,15 +50,13 @@ class TestRenderArticleTemplateTag(BaseEruditTestCase):
         self.assertTrue(ret.startswith('<div xmlns:v="variables-node" class="article-wrapper">'))
 
     @unittest.mock.patch.object(ArticleDigitalObject, 'pdf')
-    @unittest.mock.patch.object(ArticleDigitalObject, 'erudit_xsd300')
-    @unittest.mock.patch.object(ArticleDigitalObject, '_get_datastreams')
-    def test_can_transform_article_xml_to_html_when_pdf_exists(self, mock_ds, mock_xsd300, mock_pdf):
+    def test_can_transform_article_xml_to_html_when_pdf_exists(
+        self, mock_pdf, mock_has_coverpage, mock_ds, mock_xsd300
+    ):
         # Setup
         with open(FIXTURE_ROOT + '/article.xml', mode='r') as fp:
             xml = fp.read()
         fp = open(FIXTURE_ROOT + '/article.pdf', mode='rb')
-        mock_ds.return_value = ['ERUDITXSD300', ]  # noqa
-        mock_xsd300.content = unittest.mock.MagicMock()
         mock_xsd300.content.serialize = unittest.mock.MagicMock(return_value=xml)
         mock_pdf.exists = True
         mock_pdf.content = fp


### PR DESCRIPTION
- Abstract page (followed by full-text button)
  - [Cultural, with cover page](http://localhost:8000/fr/revues/images/2012-n160-images0407/68291ac/resume/)
  - [Scientific, with cover page](http://localhost:8000/fr/revues/ae/2014-v90-n3-ae02325/1034737ar/resume/)
  - [Scientific, without cover page - logo only](http://localhost:8000/fr/revues/meta/2011-v56-n1-meta1522519/1003507ar/resume/)
- Full-text article
  - [Cultural, with cover page](http://localhost:8000/fr/revues/images/2012-n160-images0407/68291ac/)
  - [Scientific, with cover page](http://localhost:8000/fr/revues/ae/2014-v90-n3-ae02325/1034737ar/)
  - [Scientific, without cover page - logo only](http://localhost:8000/fr/revues/meta/2011-v56-n1-meta1522519/1003507ar/)
