### PR TITLE
pdf merge: set strict and import_bookmarks to False

### DIFF
--- a/eruditorg/apps/public/journal/views.py
+++ b/eruditorg/apps/public/journal/views.py
@@ -614,9 +614,9 @@ class ArticleRawPdfView(ArticleFormatDownloadView):
             base_url=self.request.build_absolute_uri('/'))
 
         # Merges the cover page and the full article
-        merger = PdfFileMerger()
-        merger.append(coverpage)
-        merger.append(content)
+        merger = PdfFileMerger(strict=False)
+        merger.append(coverpage, import_bookmarks=False)
+        merger.append(content, import_bookmarks=False)
         merger.write(response)
         merger.close()
 


### PR DESCRIPTION
PyPDF2 has numerous issues that prevent PDFs to be merged when
the outline is malformed.