### PR TITLE
subscription: fix ip address comparison

### DIFF
--- a/eruditorg/core/subscription/managers.py
+++ b/eruditorg/core/subscription/managers.py
@@ -1,14 +1,36 @@
 # -*- coding: utf-8 -*-
 
+import logging
+
 import datetime as dt
 from urllib.parse import urlparse
 
 from django.db import models
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 class JournalAccessSubscriptionQueryset(models.QuerySet):
     def get_for_ip_address(self, ip_address):
         """ Return all the subscriptions for the given ip address """
+        from .models import InstitutionIPAddressRange
+        database_engine = settings.DATABASES[self.db]['ENGINE']
+        if 'mysql' in database_engine:
+            ip_range = InstitutionIPAddressRange.objects.extra(
+                where={
+                    "inet_aton(ip_start) <= inet_aton('{}') AND inet_aton(ip_end) >= inet_aton('{}')".format(  # noqa
+                        ip_address,
+                        ip_address
+                    )
+                }
+            )
+
+            return self.filter(institutionipaddressrange=ip_range)
+
+        if 'psycopg2' not in database_engine:
+            logger.warn("Doing string comparison on IP addresses. The results may not be accurate.")
+
         return self.filter(
             institutionipaddressrange__ip_start__lte=ip_address,
             institutionipaddressrange__ip_end__gte=ip_address)


### PR DESCRIPTION
When using mysql, use the ``inet_aton`` method to avoid doing
string comparisons on ip addresses. Postgresql does this under
the hood, so we continue using standard Django lte / gte comparisons.
Warn users of other database backends that the results will not
be accurate.