### PR TITLE
#1247 - insets and examples

### DIFF
--- a/eruditorg/static/js/controllers/public/journal/JournalDetailController.js
+++ b/eruditorg/static/js/controllers/public/journal/JournalDetailController.js
@@ -1,24 +1,25 @@
 export default {
 
   init: function() {
-    this.smoothScroll();
+    this.article = $('#journal_detail');
+    this.sticky_header_height = 0;
+
+    this.smooth_scroll();
   },
 
-  smoothScroll: function() {
+  smooth_scroll : function () {
+    this.article.on('click', 'a[href*="#"]', (e) => {
+      if( e ) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
 
-    $('a[href^="#"]').on('click',function (e) {
-      e.preventDefault();
-      var target = this.hash;
-      var $target = $(target);
+      var target = $(e.currentTarget).attr('href').replace('#', '');
+      if( !target ) return false;
 
-      $('html, body').stop().animate({
-        'scrollTop': $target.offset().top
-      }, 900, 'swing', function () {
-        window.location.hash = target;
-      });
-
+      $('html, body').animate( { scrollTop: this.article.find('#'+target).offset().top - this.sticky_header_height - 30 }, 750 );
+      return false;
     });
-
   },
 
 };

--- a/eruditorg/static/sass/components/article/_blockquotes.scss
+++ b/eruditorg/static/sass/components/article/_blockquotes.scss
@@ -1,16 +1,9 @@
 /**
- * All quotation / blockquote types
+ * All quotation / blockquote types, sources / citations
  * Includes <bloccitation>, <dedicace>, <epigraphe> and <verbatim>
  */
 
 blockquote {
-
-  .source {
-    display: block;
-    color: $dark-grey;
-    font-size: smaller;
-    text-align: right;
-  }
 
   .bloc {
 
@@ -89,4 +82,12 @@ blockquote {
 
   }
 
+}
+
+.source {
+  display: block;
+  text-align: right;
+  color: $dark-grey;
+  font-size: smaller;
+  margin-top: 0.75em;
 }

--- a/eruditorg/static/sass/components/article/_insets-examples.scss
+++ b/eruditorg/static/sass/components/article/_insets-examples.scss
@@ -1,0 +1,77 @@
+/**
+ * Insets and examples (<encadre>, <exemple>)
+ */
+
+.grencadre,
+.grexemple {
+  margin-bottom: 1em;
+
+  h1 {
+    font-size: 1em;
+    @include font-styles('sans');
+  }
+
+}
+
+.grexemple {
+  background-color: $light-grey;
+  padding: 0.75em;
+
+  .exemple {
+    padding: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+  }
+
+}
+
+
+.exemple,
+.encadre {
+  padding: 0.75em;
+
+  h1 {
+    font-size: 1em;
+    border: 0;
+    border-bottom: 1px solid $mid-grey;
+    padding: 0;
+    color: $dark-grey;
+    @include font-styles('sans');
+  }
+
+  h2, h3, h4, h5, h6 {
+    margin: 1.5em 0 0.75em 0;
+    color: #000;
+    padding: 0 0 0.25em 0;
+    border: 0;
+    border-bottom: 1px dotted $mid-grey;
+    @include font-styles('sans');
+  }
+
+  p, li, table, cite, blockquote {
+    @include font-styles('sans');
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+
+  }
+
+}
+
+.exemple {
+  background-color: $light-grey;
+  margin-bottom: 1.25em;
+
+  img {
+    mix-blend-mode: multiply;
+  }
+
+}
+
+.encadre {
+  outline: 1px solid $mid-grey;
+}

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -356,6 +356,7 @@ $article-toolbar-width: 80px;
       '../../components/article/blockquotes',
       '../../components/article/figures',
       '../../components/article/formulae',
+      '../../components/article/insets-examples',
       '../../components/article/lists',
       '../../components/article/notes',
       '../../components/article/tables';
@@ -404,7 +405,7 @@ $article-toolbar-width: 80px;
   */
   .corps {
 
-    section:first-of-type {
+    > section:first-of-type {
 
       h2 {
         margin-top: 0;

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1044,15 +1044,29 @@
   <!-- equations, examples & insets/boxed text -->
   <xsl:template match="grencadre|grequation|grexemple">
     <aside class="{name()}">
-      <xsl:apply-templates select="no"/>
-      <xsl:apply-templates select="legende"/>
+      <h1><strong><xsl:apply-templates select="no"/><xsl:apply-templates select="legende/titre"/></strong></h1>
       <xsl:apply-templates select="*[not(self::no)][not(self::legende)][not(self::titreparal)]"/>
     </aside>
   </xsl:template>
-  <xsl:template match="encadre">
-    <aside class="encadre type{@type}">
-      <xsl:apply-templates/>
+
+  <xsl:template match="encadre|exemple">
+    <aside class="{name()}">
+      <xsl:if test="legende or no">
+        <h1>
+          <strong>
+            <xsl:apply-templates select="no"/><xsl:if test="legende and no"><span>. </span></xsl:if>
+            <xsl:apply-templates select="legende"/>
+          </strong>
+        </h1>
+      </xsl:if>
+      <xsl:for-each select="node()[name() != '' and name() != 'no' and name() != 'legende']">
+        <xsl:apply-templates select="."/>
+      </xsl:for-each>
     </aside>
+  </xsl:template>
+
+  <xsl:template match="encadre/legende/titre|exemple/legende/titre|encadre/no|exemple/no">
+    <xsl:apply-templates/>
   </xsl:template>
 
   <!-- notes within equations, examples and insets -->
@@ -1085,15 +1099,6 @@
         </div>
       </xsl:if>
       <xsl:for-each select="node()[name() = 'noteeq' or name() = 'source']">
-        <xsl:apply-templates select="."/>
-      </xsl:for-each>
-    </aside>
-  </xsl:template>
-  <xsl:template match="exemple">
-    <aside class="exemple">
-      <xsl:apply-templates select="no"/>
-      <xsl:apply-templates select="legende"/>
-      <xsl:for-each select="node()[name() != '' and name() != 'no' and name() != 'legende']">
         <xsl:apply-templates select="."/>
       </xsl:for-each>
     </aside>
@@ -1622,9 +1627,9 @@
   <!-- sources -->
   <xsl:template match="source">
     <xsl:if test="text() or node()">
-      <p class="source">
+      <cite class="source">
         <xsl:apply-templates/>
-      </p>
+      </cite>
     </xsl:if>
   </xsl:template>
 

--- a/eruditorg/templates/public/journal/issue_detail.html
+++ b/eruditorg/templates/public/journal/issue_detail.html
@@ -105,8 +105,8 @@
       {% endfor %}
       <span>{{ issue.volume_title }}{% if issue.embargoed and not user_has_access_to_journal %}&nbsp;<span class="hint--bottom-left hint--no-animate" data-hint="{% trans 'L’accès aux numéros courants de ce numéro nécessite un abonnement.' %}"><span class="ion-locked"></span></span>{% endif %}</span>
     </h1>
-    {% if issue.journal.type.code == 'C' and not issue.embargoed %}
-    <p><a href="http://retro.erudit.org/feuilletage/index.html?{{ issue.journal.localidentifier }}.{{ issue.localidentifier }}@132&height=800&width=618&h_eightL=1800&w_idthL=1390&p=oui"><span class="ion-ios-book-outline"></span> {% trans 'Feuilleter ce numéro' %}</a></p>
+    {% if issue.journal.type.code == 'C' and user_has_access_to_journal %}
+    <p><a href="http://retro.erudit.org/feuilletage/index.html?{{ issue.journal.localidentifier }}.{{ issue.localidentifier }}@132&height=800&width=618&h_eightL=1800&w_idthL=1390&p=oui" class="btn btn-secondary"><span class="ion-ios-book"></span>&nbsp;&nbsp;{% trans 'Feuilleter ce numéro' %}</a></p>
     {% endif %}
     <h2>
       {% trans "Sommaire" %} ({{ articles|length }} {% trans "articles" %}){% if issue.journal.collection.code == 'unb' %}&nbsp;<span class="hint--bottom-left hint--no-animate" data-hint="{% trans 'La lecture de ces articles nécessite la redirection vers le site de la revue.' %}"><span class="ion-alert"></span></span>{% endif %}

--- a/eruditorg/templates/public/journal/journal_base.html
+++ b/eruditorg/templates/public/journal/journal_base.html
@@ -36,7 +36,8 @@
         {% endif %}
         {% endif %}
         <p>
-          <a href="{% url 'public:journal:journal_detail' journal.code %}#back-issues" class="btn btn-primary see-issues-btn" title="{% trans 'Historique de la revue' %}">
+          {% url 'public:journal:journal_detail' journal.code as journal_detail_url %}
+          <a href="{% if request.get_full_path != journal_detail_url %}{{ journal_detail_url }}{% endif %}#back-issues" class="btn btn-primary see-issues-btn" title="{% trans 'Historique de la revue' %}">
             {% trans "Voir tous les numéros" %}
           </a>
         </p>

--- a/eruditorg/templates/public/journal/partials/article_citation_modal_content.html
+++ b/eruditorg/templates/public/journal/partials/article_citation_modal_content.html
@@ -17,7 +17,7 @@
         "{{ article.title }}."
         <em>{{ article.issue.journal.name }}</em>
         {% if article.issue.volume %}{{ article.issue.volume }}{% endif %}{% if article.issue.number %}{{ article.issue.number }}{% endif %}
-        ({{ article.issue.year }}): {{ article.first_page }}–{{ article.last_page }}.
+        ({{ article.issue.year }}): {{ article.first_page }}–{{ article.last_page }}. DOI:{{ article.doi }}
       </dd>
 
       <dt>APA</dt>
@@ -33,7 +33,7 @@
         {{ article.title }}
         <em>{{ article.issue.journal.name }}</em>,
         {% if article.issue.volume %}<em>{{ article.issue.volume }}</em>{% endif %}{% if article.issue.number %}({{ article.issue.number }}){% endif %},
-        {{ article.first_page }}–{{ article.last_page }}.
+        {{ article.first_page }}–{{ article.last_page }}. DOI:{{ article.doi }}
       </dd>
 
       <dt>Chicago</dt>
@@ -48,7 +48,7 @@
         "{{ article.title }}."
         <em>{{ article.issue.journal.name }}</em>
         {% if article.issue.volume %}{{ article.issue.volume }}, {% endif %}{% if article.issue.number %}no. {{ article.issue.number }}{% endif %}
-        ({{ article.issue.year }}): {{ article.first_page }}–{{ article.last_page }}.
+        ({{ article.issue.year }}): {{ article.first_page }}–{{ article.last_page }}. DOI:{{ article.doi }}
       </dd>
     </dl>
 

--- a/eruditorg/templates/public/thesis/collection_list_base.html
+++ b/eruditorg/templates/public/thesis/collection_list_base.html
@@ -74,7 +74,7 @@
               &nbsp;
               <select id="sort_by" onChange="window.location.href=this.value">
                 {% for sort_option in available_tris.items %}
-                <option value="?sort_by={{ sort_option.0}}"{% if sort_by == sort_option.0 %} selected{% endif %}>{{ sort_option.1 }}</option>
+                <option value="?sort_by={{ sort_option.0 }}"{% if sort_by == sort_option.0 %} selected{% endif %}>{{ sort_option.1 }}</option>
                 {% endfor %}
               </select>
             </div>
@@ -86,7 +86,7 @@
           <li class="thesis row">
             <div class="col-xs-11">
               <div class="thesis-author">{{ thesis.author.lastname }}{% if thesis.author.firstname %}, {{ thesis.author.firstname }}{% endif %}</div>
-              <a href="{{ thesis.url }}" class="thesis-title" target="_blank" title="{% trans 'Consulter cette thèse' %}">{{ thesis.title }}</a>
+              <a href="{{ thesis.url }}" class="thesis-title" target="_blank" title="{% trans 'Consulter cette thèse' %}">{{ thesis.publication_year }} — {{ thesis.title }}</a>
               {% if thesis.description or thesis.keywords.all %}
               <div class="thesis-description">
                 {% if thesis.description %}
@@ -124,7 +124,7 @@
           </dl>
         </div>
         <div class="sidebar-block">
-          <h3>{% trans "En un coup d'oeil" %}</h3>
+          <h3>{% trans "En un coup d’œil" %}</h3>
           <ul class="random-theses">
             {% for thesis in random_theses %}
             <li>

--- a/eruditorg/templates/public/thesis/home.html
+++ b/eruditorg/templates/public/thesis/home.html
@@ -50,7 +50,7 @@
           {% url 'public:search:advanced_search' as advanced_search %}
           {% blocktrans %}
           <p>Érudit offre un accès centralisé aux dépôts de thèses et mémoires de plusieurs universités canadiennes. La recherche peut être effectuée sur Érudit à l’intérieur de chaque dépôt ou dans l’ensemble de ceux-ci à partir de l’<a href="{{ advanced_search }}">outil de recherche avancée</a>&nbsp;; la consultation du document nécessite cependant une redirection vers la plateforme de l’institution d’attache.</p>
-          <p>Érudit n’est pas responsable des documents diffusés dans cette zone. En cas de besoin, veuillez communiquer directement avec la personne en charge du dépôt.</p>
+          <p>Érudit n’est pas responsable des documents diffusés dans cette zone. En cas de besoin, veuillez communiquer directement avec la personne en charge du dépôt à l’université correspondante.</p>
           {% endblocktrans %}
         </div>
       </div>


### PR DESCRIPTION
.. and smaller ui fixes 

-   Insets (`<encadre>`s) :
    -   [Numbered, with title] ; [new layout]
    -   [Numbered, with title and subtitle] ; [new layout][1]
    -   [With footnote] ; [new layout][2]
    -   [With complex headings and subheadings] ; [new layout][3]
    -   [With source] ; [new layout][4]
    -   [With figure] ; [new layout][5]
    -   [With formulae (as images) and two levels of subheadings] ; [new layout][6]
-   Examples (`<exemple>s`) :
    -   [Numbered, with source] ; [new layout][7]
    -   [Numbered, with title][8] ; [new layout][9]
    -   [Title only] ; [new layout][10]
    -   [With relation list and source] ; [new layout][11]
    -   [With multiple paragraphs] ; [new layout][12]
    -   [Example group] ; [new layout][13]
    -   [Two example groups] ; [new layout][14]
    -   [With relation lists and images] ; [new layout][15]
    -   [With complex content] ; [new layout][16]
    -   [With verbatim-type citation] ; [new layout][17]

  [Numbered, with title]: https://retro.erudit.org/revue/mi/2011/v15/n2/1003452ar.html#pa39
  [new layout]: http://localhost:8000/revue/mi/2011/v15/n2/1003452ar.html#pa39
  [Numbered, with title and subtitle]: https://retro.erudit.org/revue/mi/2011/v15/n2/1003446ar.html#pa26
  [1]: http://localhost:8000/revue/mi/2011/v15/n2/1003446ar.html#pa26
  [With footnote]: https://retro.erudit.org/revue/ri/2007/v62/n4/016955ar.html#pa20
  [2]: http://localhost:8000/revue/ri/2007/v62/n4/016955ar.html#pa20
  [With complex headings and subheadings]: https://retro.erudit.org/revue/mi/2012/v16/n2/1008707ar.html#pa38
  [3]: http://localhost:8000/revue/mi/2012/v16/n2/1008707ar.html#pa38
  [With source]: https://retro.erudit.org/revue/mi/2012/v16/n2/1008707ar.html#pa21
  [4]: http://localhost:8000/revue/mi/2012/v16/n2/1008707ar.html#pa21
  [With figure]: https://retro.erudit.org/revue/ae/2012/v88/n1/1014028ar.html#pa10
  [5]: http://localhost:8000/revue/ae/2012/v88/n1/1014028ar.html#pa10
  [With formulae (as images) and two levels of subheadings]: https://retro.erudit.org/revue/ncre/2011/v14/n1/1008844ar.html#pa26
  [6]: http://localhost:8000/revue/ncre/2011/v14/n1/1008844ar.html#pa26
  [Numbered, with source]: https://retro.erudit.org/revue/meta/2011/v56/n3/1008328ar.html#pa34
  [7]: http://localhost:8000/revue/meta/2011/v56/n3/1008328ar.html#pa34
  [8]: https://retro.erudit.org/revue/rse/2013/v39/n1/1024535ar.html#pa32
  [9]: http://localhost:8000/revue/rse/2013/v39/n1/1024535ar.html#pa32
  [Title only]: https://retro.erudit.org/revue/phro/2014/v3/n3/1026393ar.html#pa25
  [10]: http://localhost:8000/revue/phro/2014/v3/n3/1026393ar.html#pa25
  [With relation list and source]: https://retro.erudit.org/revue/rssi/2012/v32/n1-2-3/1027774ar.html#pa26
  [11]: http://localhost:8000/revue/rssi/2012/v32/n1-2-3/1027774ar.html#pa26
  [With multiple paragraphs]: https://retro.erudit.org/revue/meta/2011/v56/n3/1008333ar.html#pa18
  [12]: http://localhost:8000/revue/meta/2011/v56/n3/1008333ar.html#pa18
  [Example group]: https://retro.erudit.org/revue/meta/2013/v58/n1/1023810ar.html#pa16
  [13]: http://localhost:8000/revue/meta/2013/v58/n1/1023810ar.html#pa16
  [Two example groups]: https://retro.erudit.org/revue/meta/2014/v59/n3/1028659ar.html#s2n6
  [14]: http://localhost:8000/revue/meta/2014/v59/n3/1028659ar.html#s2n6
  [With relation lists and images]: https://retro.erudit.org/revue/meta/2011/v56/n3/1008333ar.html#pa15
  [15]: http://localhost:8000/revue/meta/2011/v56/n3/1008333ar.html#pa15
  [With complex content]: https://retro.erudit.org/revue/meta/2011/v56/n3/1008334ar.html#pa42
  [16]: http://localhost:8000/revue/meta/2011/v56/n3/1008334ar.html#pa42
  [With verbatim-type citation]: https://retro.erudit.org/revue/meta/2012/v57/n4/1021225ar.html#pa22
  [17]: http://localhost:8000/revue/meta/2012/v57/n4/1021225ar.html#pa22