### PR TITLE
Article UI fixes

### DIFF
--- a/eruditorg/static/sass/components/_toolboxes.scss
+++ b/eruditorg/static/sass/components/_toolboxes.scss
@@ -114,6 +114,11 @@
 
       }
 
+      .toolbox-top {
+        font-size: 16px;
+        left: 10px;
+      }
+
       .toolbox-remove {
         font-size: 14px;
         left: 10px;

--- a/eruditorg/static/sass/components/article/_abstracts.scss
+++ b/eruditorg/static/sass/components/article/_abstracts.scss
@@ -4,7 +4,6 @@
 
 .grresume {
   padding-bottom: $padding-vertical-default;
-  border-bottom: 1px solid #000;
 
   > .resume {
     @include column-break-inside(avoid);

--- a/eruditorg/static/sass/components/article/_abstracts.scss
+++ b/eruditorg/static/sass/components/article/_abstracts.scss
@@ -7,6 +7,7 @@
   border-bottom: 1px solid #000;
 
   > .resume {
+    @include column-break-inside(avoid);
 
     h2, h3 {
       color: #333;
@@ -37,6 +38,14 @@
 
   &:last-of-type {
     border: none;
+  }
+
+  &.double-col {
+
+    @media (min-width: $screen-sm-min) {
+        @include column-count(2);
+    }
+
   }
 
 }

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -404,6 +404,8 @@ $article-toolbar-width: 80px;
   * Article body
   */
   .corps {
+    border-top: 1px solid #000;
+    padding-top: 1em;
 
     > section:first-of-type {
 

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -450,61 +450,61 @@ $article-toolbar-width: 80px;
 
     }
 
-  }
+    /**
+    * Typemarq
+    */
 
-  /**
-  * Typemarq
-  */
+    .majuscule {
+      text-transform: uppercase;
+    }
 
-  .majuscule {
-    text-transform: uppercase;
-  }
+    .petitecap {
+      font-variant: small-caps;
+    }
 
-  .petitecap {
-    font-variant: small-caps;
-  }
+    .italique, em {
+      @include fw-serif-italic;
+      .gras, strong {
+        @include fw-serif-bold-italic;
+      }
+    }
 
-  .italique, em {
-    @include fw-serif-italic;
     .gras, strong {
-      @include fw-serif-bold-italic;
+      @include fw-serif-bold;
+      .italique, em {
+        @include fw-serif-bold-italic;
+      }
     }
-  }
 
-  .gras, strong {
-    @include fw-serif-bold;
-    .italique, em {
-      @include fw-serif-bold-italic;
+    .souligne {
+      text-decoration: underline;
     }
-  }
 
-  .souligne {
-    text-decoration: underline;
-  }
-
-  .espacefixe {
-    font-size: 14px;
-    @include fw-mono;
-    .italique, em {
-      @include fw-mono-italic;
+    .espacefixe {
+      font-size: 14px;
+      @include fw-mono;
+      .italique, em {
+        @include fw-mono-italic;
+      }
     }
-  }
 
-  .barre {
-    text-decoration: line-through;
-  }
+    .barre {
+      text-decoration: line-through;
+    }
 
-  .surligne {
-    border-style: solid none none none;
-    border-with: 1px;
-  }
+    .surligne {
+      border-style: solid none none none;
+      border-with: 1px;
+    }
 
-  .filet {
-    border: 1px solid $dark-grey;
-  }
+    .filet {
+      border: 1px solid $dark-grey;
+    }
 
-  .tailleg {
-    font-size: 1.25em;
+    .tailleg {
+      font-size: 1.25em;
+    }
+
   }
 
   /**

--- a/eruditorg/static/sass/pages/public/_article-detail.scss
+++ b/eruditorg/static/sass/pages/public/_article-detail.scss
@@ -187,6 +187,13 @@ $article-toolbar-width: 80px;
       }
 
     }
+
+    .notegen {
+      margin-top: 1em;
+      padding-top: 1em;
+      border-top: 1px solid $mid-grey;
+    }
+
     .meta-article,
     .meta-journal {
       border-top: 1px solid $dark-grey;
@@ -403,18 +410,18 @@ $article-toolbar-width: 80px;
   /**
   * Article body
   */
-  .corps {
+  .grresume + .corps {
     border-top: 1px solid #000;
     padding-top: 1em;
+  }
 
+  .corps {
     > section:first-of-type {
-
       h2 {
         margin-top: 0;
         padding: 0;
         border: 0;
       }
-
     }
 
     // headings within the article body

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -241,7 +241,7 @@
                 </li>
               </xsl:if>
             </xsl:for-each>
-            {% if not only_summary %}
+            {% if article_access_granted and not only_summary %}
             <xsl:if test="//figure">
               <li>
                 <a href="#figures">{% trans "Liste des figures" %}</a>
@@ -391,7 +391,7 @@
         </div>
 
         <!-- lists of tables & figures -->
-        {% if not only_summary %}
+        {% if article_access_granted and not only_summary %}
         <xsl:if test="//figure">
           <section id="figures" class="article-section figures" role="complementary">
             <h2>{% trans "Liste des figures" %}</h2>
@@ -1852,7 +1852,13 @@
   <xsl:template match="partiesann">
     <section class="{name()}{% if article.erudit_object.processing == 'minimal' %} col-md-8{% else %} col-xs-12{% endif %}">
       <h2 class="sr-only">{% trans 'Parties annexes' %}</h2>
-      <xsl:apply-templates/>
+      {% if article_access_granted and not only_summary  %}
+      <xsl:apply-templates select="grannexe"/>
+      <xsl:apply-templates select="grnote"/>
+      {% endif %}
+      <xsl:apply-templates select="grnotebio"/>
+      <xsl:apply-templates select="grbiblio"/>
+      <xsl:apply-templates select="merci"/>
     </section>
   </xsl:template>
 
@@ -1860,7 +1866,6 @@
     <section id="{name()}" class="article-section {name()}" role="complementary">
       <h2>
         <xsl:choose>
-          {% if not only_summary %}
           <xsl:when test="self::grannexe">
             <xsl:apply-templates select="self::grannexe" mode="toc-heading"/>
           </xsl:when>
@@ -1873,7 +1878,6 @@
           <xsl:when test="self::grnote">
             <xsl:apply-templates select="self::grnote" mode="toc-heading"/>
           </xsl:when>
-          {% endif %}
           <xsl:when test="self::grbiblio">
             <xsl:apply-templates select="self::grbiblio" mode="toc-heading"/>
           </xsl:when>
@@ -1885,7 +1889,6 @@
             <xsl:apply-templates select="*[not(self::titre)]"/>
           </ol>
         </xsl:when>
-        {% if not only_summary %}
         <xsl:when test="self::grnote">
           <ol class="unstyled">
             <xsl:apply-templates select="*[not(self::titre)]"/>
@@ -1894,7 +1897,6 @@
         <xsl:otherwise>
           <xsl:apply-templates select="*[not(self::titre)]"/>
         </xsl:otherwise>
-        {% endif %}
       </xsl:choose>
     </section>
   </xsl:template>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1940,14 +1940,17 @@
   <!-- biographical notes -->
   <xsl:template match="notebio">
     <div class="notebio">
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="nompers"/>
+      <xsl:apply-templates select="*[not(self::nompers)]"/>
     </div>
   </xsl:template>
 
   <xsl:template match="notebio/nompers">
-    <h2 class="nompers">
-      <xsl:apply-templates/>
-    </h2>
+    <h3>
+      <xsl:call-template name="element_nompers_affichage">
+        <xsl:with-param name="nompers" select="../nompers"></xsl:with-param>
+      </xsl:call-template>
+    </h3>
   </xsl:template>
 
   <!-- footnotes -->

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -83,6 +83,7 @@
               </ul>
             </div>
           </xsl:if>
+          <xsl:apply-templates select="liminaire/notegen"/>
           {% if not article_access_granted and not only_summary %}
           <div class="alert alert-warning">
             <p>
@@ -151,7 +152,6 @@
               </dd>
               {% endif %}
             </dl>
-            <xsl:apply-templates select="liminaire/notegen"/>
             <xsl:apply-templates select="admin/histpapier"/>
           </div>
         </div>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -272,6 +272,11 @@
           <ul class="toolbox toolbox-compact toolbox-horizontal">
             {% spaceless %}
             <li>
+              <a class="scroll-top tool-btn tool-top" href="#top">
+                <span class="ion-android-arrow-up toolbox-top"></span>
+              </a>
+            </li>
+            <li>
               <a class="tool-btn" id="tool-citation-save-{{ article.id }}" data-citation-save="#article-{{ article.id }}"{% if article.id in request.saved_citations %} style="display:none;"{% endif %}>
                 <span class="ion-bookmark toolbox-save"></span>
               </a>

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -339,8 +339,13 @@
       <div class="full-article {% if article.erudit_object.processing == 'complet' %}col-md-7 col-md-offset-1{% else %} col-md-11{% endif %}">
         <!-- abstract -->
         <xsl:if test="//resume">
-          <section id="resume" class="article-section grresume" role="complementary">
-            <h2 class="hidden">{% trans "Résumé" %}</h2>
+          <section id="resume" role="complementary">
+            <xsl:attribute name="class">
+              article-section grresume
+              {% if article.erudit_object.processing == 'minimal' %}
+              <xsl:if test="count(//resume) > 1">double-col</xsl:if>
+              {% endif %}
+            </xsl:attribute>
             <xsl:apply-templates select="//resume"/>
           </section>
         </xsl:if>


### PR DESCRIPTION
**Authors' names in biographies**
- [multilingual, two authors](http://localhost:8000/fr/revues/cuizine/2011-v3-n1-n1/1004725ar/#grnotebio)
- [FR only, two authors](http://localhost:8000/fr/revues/cuizine/2011-v3-n1-n1/1004726ar/#grnotebio)
- [two authors, minimal](http://localhost:8000/fr/revues/ehr/2013-v79-n2-n2/1018594ar/#grnotebio)
- [three authors, minimal](http://localhost:8000/fr/revues/rel049/2015-n778-rel01849/77933ac/#grnotebio)

**Abstracts**
- [complete, two abstracts](http://localhost:8000/fr/revues/cuizine/2011-v3-n1-n1/1004726ar/)
- [minimal, two abstracts](http://localhost:8000/fr/revues/ehr/2013-v79-n2-n2/1018594ar/)

**Errata and general notes**
- [erratum as a general note](http://localhost:8000/fr/revues/meta/2016-v61-n2-meta02699/1037756ar/)
- [reference as a general note](http://localhost:8000/fr/revues/mlj/2010-v55-n3-mlj1497435/1000619ar/)
- [biography as a general note](http://localhost:8000/fr/revues/mlj/2015-v60-n4-mlj02270/1034049ar/)

