### PR TITLE
add article title formatting filters

### DIFF
--- a/eruditorg/apps/public/journal/templatetags/public_journal_tags.py
+++ b/eruditorg/apps/public/journal/templatetags/public_journal_tags.py
@@ -19,6 +19,27 @@ register = template.Library()
 
 
 @register.filter
+def format_article_html_title(article):
+    """ Formats the article html title
+
+    Display the html_title if it exists otherwise display "untitled"
+    """
+    if article.html_title:
+        return mark_safe(article.html_title)
+    else:
+        return _("[Article sans titre]")
+
+
+@register.filter
+def format_article_title(article):
+    """ Formats the article title
+
+    Display the title if it exists otherwise display "untitled"
+    """
+    return article.title if article.title else _("[Article sans titre]")
+
+
+@register.filter
 def join_author_list(author_list):
     author_list = list(author_list)
     if not author_list:

--- a/eruditorg/templates/public/journal/article_base.html
+++ b/eruditorg/templates/public/journal/article_base.html
@@ -3,7 +3,7 @@
 {% load public_journal_tags %}
 {% load cache %}
 
-{% block title %}{{ article.title|truncatechars:50 }} – {{ article.issue.journal.name|safe }}{% endblock title %}
+{% block title %}{{ article|format_article_title|truncatechars:50 }} – {{ article.issue.journal.name|safe }}{% endblock title %}
 
 {% block meta_description %}{% blocktrans with journal=article.issue.journal.name|safe article=article.title %}{{ article }}. Un article de la revue {{ journal }}, diffusée par la plateforme Érudit. {% endblocktrans %}{% endblock meta_description %}
 
@@ -158,7 +158,7 @@
   </a>
 </li>
 <li>
-  <a href="{% url 'public:journal:article_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">{{ article.title|truncatechars:50 }}</a>
+  <a href="{% url 'public:journal:article_detail' article.issue.journal.code article.issue.volume_slug article.issue.localidentifier article.localidentifier %}">{{ article|format_article_title|truncatechars:50 }}</a>
 </li>
 {% endblock breadcrumb %}
 
@@ -172,7 +172,7 @@
     {% cache FOREVER_TTL "public_article_detail_related_article" related_article.id LANGUAGE_CODE %}
     <li class="related-article col-sm-6 col-md-3">
       <a href="{% url 'public:journal:article_detail' journal_code=related_article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=related_article.issue.localidentifier localid=related_article.localidentifier %}">
-        <p class="related-article-title">{{ related_article.html_title|safe }}</p>
+        <p class="related-article-title">{{ related_article|format_article_html_title }}</p>
         {% if related_article.authors.all|length > 0 %}
         <p class="related-article-authors">{% trans 'Par' %}
           {% for author in related_article.authors.all %}{% if forloop.first %}{% else %}{% if forloop.last %} {% trans 'et' %} {% else %}, {% endif %}{% endif %}{% if author.firstname and author.lastname %}{{ author.firstname }} {{ author.lastname }}{% elif author.othername %}{{ author.othername }}{% endif %}{% endfor %}

--- a/eruditorg/templates/public/journal/article_detail.html
+++ b/eruditorg/templates/public/journal/article_detail.html
@@ -74,14 +74,14 @@
     {% if not only_summary %}
     {% if previous_article %}
     <a href="{% url 'public:journal:article_detail' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="hidden-xs hidden-sm pagination-arrow previous-page">
-      <span class="hint--bottom-right hint--no-animate" data-hint="{{ previous_article.title }}">
+      <span class="hint--bottom-right hint--no-animate" data-hint="{{ previous_article|format_article_title }}">
         <span class="ion ion-ios-arrow-left"></span>
       </span>
     </a>
     {% endif %}
     {% if next_article %}
     <a href="{% url 'public:journal:article_detail' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="hidden-xs hidden-sm pagination-arrow next-page">
-      <span class="hint--bottom-left hint--no-animate" data-hint="{{ next_article.title }}">
+      <span class="hint--bottom-left hint--no-animate" data-hint="{{ next_article|format_article_title }}">
         <span class="ion ion-ios-arrow-right"></span>
       </span>
     </a>
@@ -89,14 +89,14 @@
     {% else %}
     {% if previous_article %}
     <a href="{% url 'public:journal:article_summary' journal_code=previous_article.issue.journal.code issue_slug=previous_article.issue.volume_slug issue_localid=previous_article.issue.localidentifier localid=previous_article.localidentifier %}" class="hidden-xs hidden-sm pagination-arrow previous-page">
-      <span class="hint--bottom-right hint--no-animate" data-hint="{{ previous_article.title }}">
+      <span class="hint--bottom-right hint--no-animate" data-hint="{{ previous_article|format_article_title }}">
         <span class="ion ion-ios-arrow-left"></span>
       </span>
     </a>
     {% endif %}
     {% if next_article %}
     <a href="{% url 'public:journal:article_summary' journal_code=next_article.issue.journal.code issue_slug=next_article.issue.volume_slug issue_localid=next_article.issue.localidentifier localid=next_article.localidentifier %}" class="hidden-xs hidden-sm pagination-arrow next-page">
-      <span class="hint--bottom-left hint--no-animate" data-hint="{{ next_article.title }}">
+      <span class="hint--bottom-left hint--no-animate" data-hint="{{ next_article|format_article_title }}">
         <span class="ion ion-ios-arrow-right"></span>
       </span>
     </a>

--- a/eruditorg/templates/public/journal/article_pdf_coverpage.html
+++ b/eruditorg/templates/public/journal/article_pdf_coverpage.html
@@ -1,6 +1,7 @@
 {% load staticfiles %}
 {% load i18n %}
 {% load model_formatters %}
+{% load public_journal_tags %}
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
@@ -192,7 +193,7 @@
       <div id="journal_data_title">{{ journal.name }}</div>
     </div>
     <br />
-    <h1 class="main-title">{% trans "Article" as i18n_article_title %}{{ article.title|default:i18n_article_title }}</h1>
+    <h1 class="main-title">{% trans "Article" as i18n_article_title %}{{ article|format_article_title }}</h1>
     <div class="authors">
         {{ authors | person_list }}
     </div>

--- a/eruditorg/templates/public/journal/citation/article.bib
+++ b/eruditorg/templates/public/journal/citation/article.bib
@@ -1,5 +1,6 @@
+{% load public_journal_tags %}
 @article{{ '{' }}{{ article.localidentifier }},
-  title="{{ article.title }}",
+  title="{{ article|format_article_title }}",
   author="{% for author in article.authors.all %}{% if author.firstname and author.lastname %}{{ author.lastname }}, {{ author.firstname }}{% if not forloop.last %} and {% endif %}{% endif %}{% endfor %}",
   journal="{{ article.issue.journal.name }}",
   {% if article.issue.volume %}volume="{{ article.issue.volume }}",{% endif %}

--- a/eruditorg/templates/public/journal/citation/article.enw
+++ b/eruditorg/templates/public/journal/citation/article.enw
@@ -1,5 +1,6 @@
+{% load public_journal_tags %}
 %0 Journal Article
-%T {{ article.title }}
+%T {{ article|format_article_title }}
 %A {% with author=article.authors.all.0 %}{% if author and author.firstname and author.lastname %}{{ author.lastname }}, {{ author.firstname }}{% endif %}{% endwith %}
 %J {{ article.issue.journal.name }}
 %V {% if article.issue.volume %}{{ article.issue.volume }}{% endif %}

--- a/eruditorg/templates/public/journal/citation/article.ris
+++ b/eruditorg/templates/public/journal/citation/article.ris
@@ -1,5 +1,6 @@
+{% load public_journal_tags %}
 TY  - JOUR
-T1  - {{ article.title }}
+T1  - {{ article|format_article_title }}
 {% for author in article.authors.all %}{% if author.firstname and author.lastname %}
 A1  - {{ author.lastname }}, {{ author.firstname }}
 {% endif %}{% endfor %}

--- a/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
+++ b/eruditorg/templates/public/journal/eruditxsd300_to_html.xsl
@@ -1,4 +1,4 @@
-{% load i18n %}{% load staticfiles %}<?xml version="1.0" encoding="UTF-8"?>
+{% load i18n %}{% load staticfiles %}{%load public_journal_tags %}<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:v="variables-node" version="2.0">
   <xsl:output method="html" indent="yes" encoding="UTF-8"/>
   <xsl:strip-space elements="*"/>
@@ -308,7 +308,7 @@
               </a>
             </li>
             <li>
-              <a class="tool-btn tool-share" data-title="{{ article.title|escape }}" data-cite="#id_cite_mla_{{ article.id }}">
+              <a class="tool-btn tool-share" data-title="{{ article|format_article_title|escape }}" data-cite="#id_cite_mla_{{ article.id }}">
                 <span class="ion-android-share toolbox-share"></span>
               </a>
             </li>
@@ -345,7 +345,7 @@
               </a>
             </li>
             <li>
-              <a class="tool-btn tool-share" data-title="{{ article.title|escape }}" data-cite="#id_cite_mla_{{ article.id }}">
+              <a class="tool-btn tool-share" data-title="{{ article|format_article_title|escape }}" data-cite="#id_cite_mla_{{ article.id }}">
                 <span class="ion-android-share toolbox-share"></span>
                 <span class="tools-label">{% trans "Partager" %}</span>
               </a>

--- a/eruditorg/templates/public/journal/partials/issue_detail_article_item.html
+++ b/eruditorg/templates/public/journal/partials/issue_detail_article_item.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load cache %}
 {% load model_formatters %}
+{% load public_journal_tags %}
 
 {% cache FOREVER_TTL "public_issue_detail_articles_item" article.id LANGUAGE_CODE %}
 <li class="article-item{% if not article.publication_allowed %} article-restricted{% endif %}">
@@ -37,7 +38,7 @@
     {% spaceless %}
     <a href="
     {% if article.external_url %}{% url 'public:journal:article_external_redirect' article.localidentifier %}{% else %}{% url 'public:journal:article_detail' journal_code=article.issue.journal.code issue_slug=article.issue.volume_slug issue_localid=article.issue.localidentifier localid=article.localidentifier %}{% endif %}" {% if issue.journal.collection.code == 'unb' %}target="_blank"{% endif %} title="{% blocktrans %}Lire l'article{% endblocktrans %}">
-    {{ article.html_title|safe|default:article.title }}
+    {{ article|format_article_html_title }}
     </a>
     {% endspaceless %}
   </h6>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.10.4
-git+https://github.com/erudit/liberuditarticle.git@0.2.0#egg=liberuditarticle
+git+https://github.com/erudit/liberuditarticle.git@0.2.1#egg=liberuditarticle
 git+https://github.com/erudit/erudit-core.git@0.4.16#egg=erudit-core
 git+https://github.com/erudit/django-resumable-uploads.git@1.0.1#egg=django-resumable-uploads
 git+https://github.com/erudit/django-account-actions.git@master#egg=django-account-actions

--- a/tests/unit/base/test_pdf.py
+++ b/tests/unit/base/test_pdf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import unittest
 import io
 import os.path as op
 import pytest
@@ -14,7 +14,7 @@ from erudit.fedora.modelmixins import FedoraMixin
 from base.pdf import generate_pdf
 
 
-def get_mocked_erudit_object():
+def get_mocked_erudit_object(self):
     m = unittest.mock.MagicMock()
     m.get_formatted_title.return_value = "mocked title"
     return m


### PR DESCRIPTION
Add format_article_html_title and format_article_title filters.

Display the article title (or html title) or "Untitled article"
if no title or html_title is available

Use these filters to display the title in the website. Does not update
the metadata.

http://localhost:8000/fr/revues/images/2012-n158-images0338/67659ac/

ref #3037